### PR TITLE
fix: analyse exported imports

### DIFF
--- a/src/lib/ts/analyse-dependencies-transformer.spec.ts
+++ b/src/lib/ts/analyse-dependencies-transformer.spec.ts
@@ -1,0 +1,61 @@
+import { tags } from '@angular-devkit/core';
+import { expect } from 'chai';
+import * as ts from 'typescript';
+import { analyseDependencies, DependencyAnalyser } from './analyse-dependencies-transformer';
+import { createSourceFile, createSourceText } from '../../testing/typescript.testing';
+
+describe(`analyseDependencies()`, () => {
+  it('should detect imported dependencies', () => {
+    const fooSourceFile = createSourceFile(
+      createSourceText`
+        import { CommonModule } from '@angular/common';
+        import { NgModule } from '@angular/core';
+
+        import { SecondaryModule } from '@foo/secondary';
+
+        import { SomeComponent } from './some.component';
+
+        @NgModule({
+          imports: [
+            CommonModule,
+            SecondaryModule
+          ],
+          declarations: [SomeComponent],
+          exports: [SomeComponent]
+        })
+        export class FooModule { }
+        `,
+      '/foo-bar/foo.module.ts'
+    );
+
+    const dependencies = [];
+
+    const analyser: DependencyAnalyser = (sourceFile, moduleId) => {
+      dependencies.push(moduleId);
+    };
+
+    const fooSourceTransformed = ts.transform(fooSourceFile, [analyseDependencies(analyser)]);
+
+    expect(dependencies).to.deep.equal(['@angular/common', '@angular/core', '@foo/secondary', './some.component']);
+  });
+
+  it('should detect exported imports', () => {
+    const fooSourceFile = createSourceFile(
+      createSourceText`
+        export * from '@foo';
+        export * from '@foo/secondary';
+        `,
+      '/foo-bar/public-api.ts'
+    );
+
+    const dependencies = [];
+
+    const analyser: DependencyAnalyser = (sourceFile, moduleId) => {
+      dependencies.push(moduleId);
+    };
+
+    const fooSourceTransformed = ts.transform(fooSourceFile, [analyseDependencies(analyser)]);
+
+    expect(dependencies).to.deep.equal(['@foo', '@foo/secondary']);
+  });
+});

--- a/src/lib/ts/analyse-dependencies-transformer.ts
+++ b/src/lib/ts/analyse-dependencies-transformer.ts
@@ -19,10 +19,24 @@ export const analyseDependencies = (analyser: DependencyAnalyser) => (context: t
     return text.substring(1, text.length - 1);
   };
 
+  const findModuleIdFromExport = (node: ts.ExportDeclaration) => {
+    if (!node.moduleSpecifier) {
+      return undefined;
+    }
+
+    const text = node.moduleSpecifier.getText();
+
+    return text.substring(1, text.length - 1);
+  };
+
   const visitImports: ts.Visitor = node => {
     if (ts.isImportDeclaration(node)) {
       // Found an 'import ...' declaration
       const importedModuleId: string = findModuleIdFromImport(node);
+      analyser(node.getSourceFile(), importedModuleId);
+    } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+      // Found an 'export ... from ...' declaration
+      const importedModuleId: string = findModuleIdFromExport(node);
       analyser(node.getSourceFile(), importedModuleId);
     } else {
       return ts.visitEachChild(node, visitImports, context);


### PR DESCRIPTION
## I'm submitting a...

```
[X] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description

Inspired by the angular/material2 library I have a [`public-api.ts`](https://github.com/angular/material2/blob/master/src/lib/public-api.ts) file that re-export secondary entrypoints. However the dependencies from the `public-api.ts` file are not detected by [`analyseDependencies`](https://github.com/dherges/ng-packagr/blob/master/src/lib/ts/analyse-dependencies-transformer.ts).

My `public-api.ts` file worked back on version 2.0.0-rc.13, I have not upgraded until now.

I have added a fix to that and a couple of unit tests, but I'm not sure the code/logic is written as you would like it. Feel free to change it or reject this pull request.


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
