### PR TITLE
fix: npm-import option of lessc.

### DIFF
--- a/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
+++ b/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
@@ -64,7 +64,7 @@ export class StylesheetProcessor {
       case '.less':
         log.debug(`rendering less from ${filePath}`);
         // this is the only way I found to make LESS sync
-        let cmd = `node node_modules/less/bin/lessc ${filePath} --less-plugin-npm-import="prefix=~"`;
+        let cmd = `node node_modules/less/bin/lessc ${filePath} --npm-import="prefix=~"`;
         if (this.styleIncludePaths.length) {
           cmd = `${cmd} --include-path=${this.styleIncludePaths.join(':')}`;
         }


### PR DESCRIPTION
## I'm submitting a...

```
[x ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
An error has occurred because the option specified lessc is wrong.
I corrected it to the correct option.
```
Error: : Error: Command failed: node node_modules/less/bin/lessc C:\Workspace\Jenkins\jobs\ng-hue-lib-demo\workspace\src\lib\component\button\button.less --less-plugin-npm-import="prefix=~"
Unable to interpret argument less-plugin-npm-import - if it is a plugin (less-plugin-less-plugin-npm-import), make sure that it is installed under or at the same level as less

    at checkExecSyncError (child_process.js:574:11)
    at Object.execSync (child_process.js:611:13)
    at StylesheetProcessor.renderPreProcessor (C:\Workspace\Jenkins\jobs\ng-hue-lib-demo\workspace\node_modules\ng-packagr\lib\ng-v5\entry-point\resources\stylesheet-processor.js:65:40)
    at StylesheetProcessor.process (C:\Workspace\Jenkins\jobs\ng-hue-lib-demo\workspace\node_modules\ng-packagr\lib\ng-v5\entry-point\resources\stylesheet-processor.js:25:34)
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```
