### PR TITLE
fix: `JavaScript heap out of memory` when having a lot of secondary entrypoints

### DIFF
--- a/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
+++ b/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
@@ -16,14 +16,15 @@ export const compileNgcTransform: Transform = transformFromPromise(async graph =
 
   // Compile TypeScript sources
   const { esm2015, esm5, declarations } = entryPoint.data.destinationFiles;
-  const { sourcesFileCache, moduleResolutionCache } = entryPoint.cache;
+  const { moduleResolutionCache } = entryPoint.cache;
   const { basePath, cssUrl, styleIncludePaths } = entryPoint.data.entryPoint;
   const stylesheetProcessor = new StylesheetProcessor(basePath, cssUrl, styleIncludePaths);
 
   await Promise.all([
     compileSourceFiles(
+      graph,
+      entryPoint,
       tsConfig,
-      sourcesFileCache,
       moduleResolutionCache,
       stylesheetProcessor,
       {
@@ -34,7 +35,7 @@ export const compileNgcTransform: Transform = transformFromPromise(async graph =
       path.dirname(declarations)
     ),
 
-    compileSourceFiles(tsConfig, sourcesFileCache, moduleResolutionCache, stylesheetProcessor, {
+    compileSourceFiles(graph, entryPoint, tsConfig, moduleResolutionCache, stylesheetProcessor, {
       outDir: path.dirname(esm5),
       target: ts.ScriptTarget.ES5,
       downlevelIteration: true,

--- a/src/lib/ng-v5/nodes.ts
+++ b/src/lib/ng-v5/nodes.ts
@@ -57,6 +57,14 @@ export function ngUrl(path: string): string {
 export class EntryPointNode extends Node {
   readonly type = TYPE_NG_ENTRY_POINT;
 
+  constructor(public readonly url: string, readonly sourcesFileCache?: FileCache) {
+    super(url);
+
+    if (sourcesFileCache) {
+      this.cache.sourcesFileCache = sourcesFileCache;
+    }
+  }
+
   cache = {
     sourcesFileCache: new FileCache(),
     moduleResolutionCache: ts.createModuleResolutionCache(process.cwd(), s => s),
@@ -73,4 +81,8 @@ export class EntryPointNode extends Node {
 export class PackageNode extends Node {
   readonly type = TYPE_NG_PACKAGE;
   data: NgPackage;
+
+  cache = {
+    sourcesFileCache: new FileCache()
+  };
 }

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -4,12 +4,14 @@ import * as log from '../util/log';
 import { createEmitCallback } from './create-emit-callback';
 import { redirectWriteFileCompilerHost } from '../ts/redirect-write-file-compiler-host';
 import { cacheCompilerHost } from '../ts/cache-compiler-host';
-import { FileCache } from '../file/file-cache';
 import { StylesheetProcessor } from '../ng-v5/entry-point/resources/stylesheet-processor';
+import { BuildGraph } from '../brocc/build-graph';
+import { EntryPointNode } from '../ng-v5/nodes';
 
 export async function compileSourceFiles(
+  graph: BuildGraph,
+  entryPoint: EntryPointNode,
   tsConfig: ng.ParsedConfiguration,
-  sourcesFileCache: FileCache,
   moduleResolutionCache: ts.ModuleResolutionCache,
   stylesheetProcessor: StylesheetProcessor,
   extraOptions?: Partial<ng.CompilerOptions>,
@@ -19,7 +21,13 @@ export async function compileSourceFiles(
 
   const tsConfigOptions: ng.CompilerOptions = { ...tsConfig.options, ...extraOptions };
 
-  let tsCompilerHost = cacheCompilerHost(tsConfigOptions, sourcesFileCache, moduleResolutionCache, stylesheetProcessor);
+  let tsCompilerHost = cacheCompilerHost(
+    graph,
+    entryPoint,
+    tsConfigOptions,
+    moduleResolutionCache,
+    stylesheetProcessor
+  );
   if (declarationDir) {
     tsCompilerHost = redirectWriteFileCompilerHost(tsCompilerHost, tsConfigOptions.basePath, declarationDir);
   }


### PR DESCRIPTION

Previously we had a source file cache for each entrypoint, with this change we unify it to have a single one for all the entrypoints, so that when having a lot of entrypoints we don't cache node_modules and files more than once.

Closes #1099
