### PR TITLE
fix: add support for TypeScript 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@angular/compiler-cli": "^6.0.0 || ^7.0.0-beta.0",
     "tsickle": ">=0.27.3",
     "tslib": "^1.9.0",
-    "typescript": "^2.7.0 || ~3.0.1"
+    "typescript": ">= 2.7 <3.2"
   },
   "devDependencies": {
     "@angular-devkit/core": "^0.8.0",


### PR DESCRIPTION
Angular 7 RC.0 requires TypeScript 3.1+