### PR TITLE
fix: tsconfig path mapping

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -132,7 +132,7 @@ export function setDependenciesTsConfigPaths(
     if (!tsConfig.options.paths[moduleId]) {
       tsConfig.options.paths[moduleId] = mappedPath;
     } else {
-      tsConfig.options.paths[moduleId].concat(mappedPath).reverse();
+      tsConfig.options.paths[moduleId].unshift(...mappedPath);
     }
   }
 


### PR DESCRIPTION
Concat doesnt mutate the array but rather return a new instance which at the moment is not being used.