### PR TITLE
fix: use ts.compilerHost as moduleResolutionHost for tsickle.emitWith…

### DIFF
--- a/src/lib/ngc/create-emit-callback.ts
+++ b/src/lib/ngc/create-emit-callback.ts
@@ -64,7 +64,7 @@ export function createEmitCallback(options: api.CompilerOptions): api.TsEmitCall
   }) =>
     tsickle.emitWithTsickle(
       program,
-      { ...tsickleHost, options, host },
+      { ...tsickleHost, options, ...{ host } },
       host,
       options,
       targetSourceFile,


### PR DESCRIPTION
Compilation fails with exception of get directoryExists on undefined

TypeError: Cannot read property 'directoryExists' of undefined
    at Object.directoryProbablyExists
Because of moduleResolutionHost is undefined due TsickleHost created does not contain host property
Related lines:
https://github.com/angular/tsickle/blob/master/src/tsickle.ts#L172
https://github.com/Microsoft/TypeScript/blob/0a7c92864d628c02e450f23ab2547ed1f5954b56/src/compiler/utilities.ts#L4019

Fixes: https://github.com/ng-packagr/ng-packagr/issues/1189