### PR TITLE
perf: reduce the calls to dependsOn

### DIFF
--- a/src/lib/brocc/node.ts
+++ b/src/lib/brocc/node.ts
@@ -44,10 +44,14 @@ export class Node {
   public dependsOn(dependent: Node | Node[]) {
     const newDeps = dependent instanceof Array ? dependent : [dependent];
 
-    newDeps.forEach(dep => (dep._dependees = dep._dependees.filter(d => d.url !== this.url).concat(this)));
+    for (const newDep of newDeps) {
+      if (newDep._dependees.some(x => x.url === this.url)) {
+        // nodes already depends on each other
+        continue;
+      }
 
-    this._dependents = this._dependents
-      .filter(existing => newDeps.some(newDep => newDep.url !== existing.url))
-      .concat(newDeps);
+      newDep._dependees.push(this);
+      this._dependents.push(newDep);
+    }
   }
 }


### PR DESCRIPTION
This call is heavy when having a lot of nodes. It has multiple concats and filters and can cause perf issues when having a lot of nodes
