### PR TITLE
feat: remove tsickle from direct peerDepedencies

### DIFF
--- a/integration/samples/core/specs/es2015-api.ts
+++ b/integration/samples/core/specs/es2015-api.ts
@@ -36,8 +36,8 @@ describe(`@sample/core`, () => {
       expect(API.AngularService).to.be.ok;
     });
 
-    it(`should not import TS helpers from 'tslib'`, () => {
-      expect(BUNDLE).not.to.contain('tslib');
+    it(`should import TS helpers from 'tslib'`, () => {
+      expect(BUNDLE).to.contain('tslib');
     });
   });
 });

--- a/integration/samples/core/specs/es5-api.ts
+++ b/integration/samples/core/specs/es5-api.ts
@@ -36,7 +36,7 @@ describe(`@sample/core`, () => {
     });
 
     it(`should import TS helpers from 'tslib'`, () => {
-      expect(BUNDLE).to.contain(`import { __spread } from 'tslib'`);
+      expect(BUNDLE).to.contain('tslib');
     });
 
     it(`should downlevel iteration`, () => {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "peerDependencies": {
     "@angular/compiler": "^6.0.0 || ^7.0.0 || ^7.2.0-beta.0",
     "@angular/compiler-cli": "^6.0.0 || ^7.0.0 || ^7.2.0-beta.0",
-    "tsickle": ">=0.34.0",
     "tslib": "^1.9.0",
     "typescript": ">= 2.7 <3.3"
   },

--- a/src/lib/ngc/create-emit-callback.ts
+++ b/src/lib/ngc/create-emit-callback.ts
@@ -52,28 +52,36 @@ export function createEmitCallback(options: api.CompilerOptions): api.TsEmitCall
     transformTypesToClosure
   };
 
-  return ({
-    program,
-    targetSourceFile,
-    writeFile,
-    cancellationToken,
-    emitOnlyDtsFiles,
-    customTransformers = {},
-    host,
-    options
-  }) =>
-    tsickle.emitWithTsickle(
+  if (options.annotateForClosureCompiler || options.annotationsAs === 'static fields') {
+    return ({
       program,
-      { ...tsickleHost, options, moduleResolutionHost: host },
-      host,
-      options,
       targetSourceFile,
       writeFile,
       cancellationToken,
       emitOnlyDtsFiles,
-      {
-        beforeTs: customTransformers.before,
-        afterTs: customTransformers.after
-      }
-    );
+      customTransformers = {},
+      host,
+      options
+    }) =>
+      require('tsickle').emitWithTsickle(
+        program,
+        { ...tsickleHost, options, moduleResolutionHost: host },
+        host,
+        options,
+        targetSourceFile,
+        writeFile,
+        cancellationToken,
+        emitOnlyDtsFiles,
+        {
+          beforeTs: customTransformers.before,
+          afterTs: customTransformers.after
+        }
+      );
+  } else {
+    return ({ program, targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers = {} }) =>
+      program.emit(targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, {
+        after: customTransformers.after,
+        before: customTransformers.before
+      });
+  }
 }

--- a/src/lib/ts/conf/tsconfig.ngc.json
+++ b/src/lib/ts/conf/tsconfig.ngc.json
@@ -1,6 +1,5 @@
 {
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION


Fix #1202

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

BREAKING CHANGE: Users outside of Google don't usually need closure annotations hence `annotateForClosureCompiler` is turned off by default. In case users want to emit closure compatable code. they need to install `tsickle` and enable opt it this feature.
## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
