### PR TITLE
fix: emit ts option diagnostic

### DIFF
--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -62,6 +62,7 @@ export async function compileSourceFiles(
   cache.oldPrograms = { ...cache.oldPrograms, [scriptTarget]: ngProgram };
 
   const allDiagnostics = [
+    ...ngProgram.getTsOptionDiagnostics(),
     ...ngProgram.getNgOptionDiagnostics(),
     ...ngProgram.getTsSyntacticDiagnostics(),
     ...ngProgram.getTsSemanticDiagnostics(),


### PR DESCRIPTION
In some cases, when a direct dependency is not build we are not emitting an error and rollup would would because the entrypoint cannot be resolved.

Closes https://github.com/angular/angular-cli/issues/14164
