### PR TITLE
build: remove irrelevant scripts section removal warning

### DIFF
--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -110,13 +110,15 @@ export async function writePackageJson(
   }
 
   // Removes scripts from package.json after build
-  if (pkg.keepLifecycleScripts !== true) {
-    log.info(`Removing scripts section in package.json as it's considered a potential security vulnerability.`);
-    delete packageJson.scripts;
-  } else {
-    log.warn(
-      `You enabled keepLifecycleScripts explicitly. The scripts section in package.json will be published to npm.`
-    );
+  if (packageJson.scripts) {
+    if (pkg.keepLifecycleScripts !== true) {
+      log.info(`Removing scripts section in package.json as it's considered a potential security vulnerability.`);
+      delete packageJson.scripts;
+    } else {
+      log.warn(
+        `You enabled keepLifecycleScripts explicitly. The scripts section in package.json will be published to npm.`
+      );
+    }
   }
 
   // keep the dist package.json clean


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Removes the messages related to the scripts section of `package.json` when that section does not exist. The `Removing scripts section in package.json as it's considered a potential security vulnerability.` message should not exist when there is no scripts section to cause a **potential security vulnerability**.

```
... 
Building Angular Package
Building entry point '@scope/packages/subpackage1'
Compiling TypeScript sources through ngc
Bundling to FESM2015
Bundling to FESM5
Bundling to UMD
Minifying UMD bundle
Copying declaration files
Writing package metadata
Removing scripts section in package.json as it's considered a potential security vulnerability.
Built @scope/packages/subpackage1
Building entry point '@scope/packages/subpackage2'
...
```



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
