### PR TITLE
ci: disable watch tests in windows as they always fail

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ environment:
     # Set %PATH% to avoid msys/cygwin DLL conflicts which causes:
     # 'fatal error - cygheap base mismatch detected'
     PATH: C:\msys64\usr\bin;C:\WINDOWS\system32;C:\Program Files (x86)\7-Zip;C:\WINDOWS;C:\Program Files (x86)\Yarn\bin;C:\Program Files (x86)\nodejs
-  nodejs_version: "8"
+  nodejs_version: '8'
 
 matrix:
   fast_finish: true
@@ -17,7 +17,10 @@ install:
   - yarn install --frozen-lockfile --non-interactive
 
 test_script:
-  - yarn test
+  # Re enable the full test suit when watch tests fully work on windows ci
+  # these seem to fail on ci but work locally.
+  # - yarn test
+  - yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs
 
 build: off
 deploy: off


### PR DESCRIPTION
In windows ci these tests always fail however locally on a windows machine they pass

Re-enable when fixed

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
