### PR TITLE
fix: fix resolution for less binary

### DIFF
--- a/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
+++ b/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
@@ -71,9 +71,9 @@ export class StylesheetProcessor {
 
       case '.less':
         // this is the only way I found to make LESS sync
-        let cmd = `node node_modules/less/bin/lessc "${filePath}" --less-plugin-npm-import="prefix=~"`;
+        let cmd = `node "${require.resolve('less/bin/lessc')}" "${filePath}" --less-plugin-npm-import="prefix=~"`;
         if (this.styleIncludePaths.length) {
-          cmd = `${cmd} --include-path=${this.styleIncludePaths.join(':')}`;
+          cmd += ` --include-path=${this.styleIncludePaths.join(':')}`;
         }
 
         return execSync(cmd).toString();


### PR DESCRIPTION
Use `require.resolve` to always resolve to the correct less binary

Fixes #1276
