### PR TITLE
fix: remove deprecated sponsoring badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square)](https://conventionalcommits.org)
 [![CircleCI](https://img.shields.io/circleci/project/github/ng-packagr/ng-packagr/master.svg?label=Circle%20CI&style=flat-square)](https://circleci.com/gh/ng-packagr/ng-packagr)
 
-[![Backers on Open Collective](https://opencollective.com/ng-packagr/backers/badge.svg?style=flat-square)](#backers)
-[![Sponsors on Open Collective](https://opencollective.com/ng-packagr/sponsors/badge.svg?style=flat-square)](#sponsors)
 [![GitHub contributors](https://img.shields.io/github/contributors/ng-packagr/ng-packagr.svg?style=flat-square)](https://github.com/ng-packagr/ng-packagr)
 [![GitHub stars](https://img.shields.io/github/stars/ng-packagr/ng-packagr.svg?label=GitHub%20Stars&style=flat-square)](https://github.com/ng-packagr/ng-packagr)
 [![npm Downloads](https://img.shields.io/npm/dw/ng-packagr.svg?style=flat-square)](https://www.npmjs.com/package/ng-packagr)


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Removes the sponsoring links that are now outdated due to https://github.com/ng-packagr/ng-packagr/pull/1296

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
