### PR TITLE
fix: add quotes to less include-path

### DIFF
--- a/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
+++ b/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
@@ -73,7 +73,7 @@ export class StylesheetProcessor {
         // this is the only way I found to make LESS sync
         let cmd = `node "${require.resolve('less/bin/lessc')}" "${filePath}" --less-plugin-npm-import="prefix=~" --js`;
         if (this.styleIncludePaths.length) {
-          cmd += ` --include-path=${this.styleIncludePaths.join(':')}`;
+          cmd += ` --include-path="${this.styleIncludePaths.join(':')}"`;
         }
 
         return execSync(cmd).toString();


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Added quote marks to the include-path parameter when bundling `.less` files.
Without this, having whitespace characters in the path of any file specified by the `styleIncludePaths` configuration breaks the packaging process.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
