### PR TITLE
feat: use `ajv` to validate schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "main": "./public_api.js",
   "typings": "./public_api.d.ts",
   "dependencies": {
-    "@ngtools/json-schema": "^1.1.0",
+    "ajv": "^6.10.2",
     "autoprefixer": "^9.6.0",
     "browserslist": "^4.0.0",
     "chalk": "^2.3.1",

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import { SchemaClass } from '@ngtools/json-schema';
 import { NgPackageConfig } from '../../ng-package.schema';
 import { DirectoryPath, SourceFilePath, CssUrl, DestinationFiles } from './shared';
 
@@ -38,8 +37,6 @@ export class NgEntryPoint {
     public readonly packageJson: any,
     /** Values from either the `ngPackage` option (from `package.json`) or values from `ng-package.json`. */
     public readonly ngPackageJson: NgPackageConfig,
-    /** Corresponding JSON schema class instantiated from `ngPackageJson` values. */
-    private readonly $schema: SchemaClass<NgPackageConfig>,
     /** Absolute directory path of this entry point's `package.json` location. */
     public readonly basePath: string,
     /** XX: additional auto-configured data passed for scondary entry point's. Needs better docs. */
@@ -90,7 +87,14 @@ export class NgEntryPoint {
   }
 
   public $get(key: string): any {
-    return this.$schema.$$get(key);
+    const parts = key.split('.');
+    let value = this.ngPackageJson;
+
+    for (const key of parts) {
+      value = value[key];
+    }
+
+    return value;
   }
 
   public get entryFile(): SourceFilePath {
@@ -115,8 +119,8 @@ export class NgEntryPoint {
 
   public get styleIncludePaths(): string[] {
     const includePaths = this.$get('lib.styleIncludePaths') || [];
-    return includePaths.map(includePath =>
-      path.isAbsolute(includePath) ? includePath : path.resolve(this.basePath, includePath),
+    return includePaths.map(
+      includePath => (path.isAbsolute(includePath) ? includePath : path.resolve(this.basePath, includePath)),
     );
   }
 

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -14,26 +14,17 @@
       "default": true
     },
     "dest": {
-      "description":
-        "Destination folder where distributable binaries of the Angular library are written (default: `dist`).",
+      "description": "Destination folder where distributable binaries of the Angular library are written (default: `dist`).",
       "type": "string",
       "default": "dist"
     },
     "keepLifecycleScripts": {
-      "description":
-        "Enable this to keep the 'scripts' section in package.json. Read the NPM Blog on 'Package install scripts vulnerability' – http://blog.npmjs.org/post/141702881055/package-install-scripts-vulnerability",
+      "description": "Enable this to keep the 'scripts' section in package.json. Read the NPM Blog on 'Package install scripts vulnerability' – http://blog.npmjs.org/post/141702881055/package-install-scripts-vulnerability",
       "type": "boolean",
       "default": false
     },
-    "workingDirectory": {
-      "description":
-        "Internal working directory of ng-packagr where intermediate build files are stored (default: `.ng_pkg_build`).",
-      "type": "string",
-      "default": ".ng_pkg_build"
-    },
     "whitelistedNonPeerDependencies": {
-      "description":
-        "A list of dependencies that are allowed in the 'dependencies' and 'devDependencies' section of package.json. Values in the list are regular expressions matched against npm package names.",
+      "description": "A list of dependencies that are allowed in the 'dependencies' and 'devDependencies' section of package.json. Values in the list are regular expressions matched against npm package names.",
       "type": "array",
       "items": {
         "type": "string"
@@ -43,6 +34,7 @@
     "lib": {
       "description": "Description of the library's entry point.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "entryFile": {
           "description": "Entry file to the public API (default: `src/public_api.ts`).",
@@ -50,20 +42,17 @@
           "default": "src/public_api.ts"
         },
         "flatModuleFile": {
-          "description":
-            "Filename of the auto-generated flat module file (if empty, defaults to the package name as given in `package.json`).",
+          "description": "Filename of the auto-generated flat module file (if empty, defaults to the package name as given in `package.json`).",
           "type": "string",
           "default": ""
         },
         "umdModuleIds": {
-          "description":
-            "A map of external dependencies and their correspondent UMD module identifiers. Map keys are TypeScript / EcmaScript module identifiers. Map values are UMD module ids. The purpose of this map is to correctly bundle an UMD module file (with `rollup`). By default, `rxjs`, `tslib` and `@angular/*` dependency symbols are supported.",
+          "description": "A map of external dependencies and their correspondent UMD module identifiers. Map keys are TypeScript / EcmaScript module identifiers. Map values are UMD module ids. The purpose of this map is to correctly bundle an UMD module file (with `rollup`). By default, `rxjs`, `tslib` and `@angular/*` dependency symbols are supported.",
           "type": "object",
           "additionalProperties": true
         },
         "jsx": {
-          "description":
-            "A property to indicate whether your library is going to be bundling jsx/tsx files. This passes through to tsconfig - see https://www.typescriptlang.org/docs/handbook/jsx.html",
+          "description": "A property to indicate whether your library is going to be bundling jsx/tsx files. This passes through to tsconfig - see https://www.typescriptlang.org/docs/handbook/jsx.html",
           "type": "string",
           "enum": ["preserve", "react", "react-native", ""],
           "default": ""
@@ -82,8 +71,7 @@
           }
         },
         "languageLevel": {
-          "description":
-            "Set typescript language level, i.e. tsconfig.lib. This will enable accessing typescript features available in es2016, es2017, etc.",
+          "description": "Set typescript language level, i.e. tsconfig.lib. This will enable accessing typescript features available in es2016, es2017, etc.",
           "type": "array",
           "items": {
             "type": "string"
@@ -91,13 +79,11 @@
           "default": ["dom", "es2015"]
         },
         "amdId": {
-          "description":
-            "ID for AMD module. By default, uses a value derived from the entry point's module ID (i.e., name property in package.json)",
+          "description": "ID for AMD module. By default, uses a value derived from the entry point's module ID (i.e., name property in package.json)",
           "type": "string"
         },
         "umdId": {
-          "description":
-            "ID for the UMD bundle. By default, uses a value derived from the entry point's module ID (i.e., name property in package.json)",
+          "description": "ID for the UMD bundle. By default, uses a value derived from the entry point's module ID (i.e., name property in package.json)",
           "type": "string"
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,11 +216,6 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@ngtools/json-schema@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ngtools/json-schema/-/json-schema-1.1.0.tgz#c3a0c544d62392acc2813a42c8a0dc6f58f86922"
-  integrity sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI=
-
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -467,6 +462,16 @@ ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 amdefine@>=0.0.4:
   version "1.0.1"
@@ -2004,6 +2009,11 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -3102,6 +3112,11 @@ json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
   integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -4388,6 +4403,11 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -5618,6 +5638,13 @@ update-notifier@^3.0.0:
     latest-version "^5.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Remove deprecate `@ngtools/json-schema` in favour of ajv
