### PR TITLE
feat: show error when trying to publish ivy packages

### DIFF
--- a/integration/samples/apf/specs/package.ts
+++ b/integration/samples/apf/specs/package.ts
@@ -11,6 +11,10 @@ describe(`@sample/apf`, () => {
       expect(PACKAGE).to.be.ok;
     });
 
+    it(`should not have 'prepublishOnly' script`, () => {
+      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
+    });
+
     it(`should have 'tslib' as a dependency`, () => {
       expect(PACKAGE.dependencies.tslib).to.be.ok;
     });
@@ -76,6 +80,10 @@ describe(`@sample/apf`, () => {
 
     it(`should exist`, () => {
       expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should not have 'prepublishOnly' script`, () => {
+      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
     });
 
     it(`should not have ngPackage field`, () => {

--- a/integration/samples/ivy/specs/package.ts
+++ b/integration/samples/ivy/specs/package.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+describe('@sample/ivy', () => {
+  describe(`package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = require('../dist/package.json');
+    });
+
+    it('should exist', () => {
+      expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should have 'prepublishOnly' script`, () => {
+      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.ok;
+    });
+  });
+
+  describe(`secondary/package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = require('../dist/secondary/package.json');
+    });
+
+    it('should exist', () => {
+      expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should not have 'prepublishOnly' script`, () => {
+      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
Publishing of Ivy packages should not be allowed, as there Ivy packages are not backward compatible with VE applications.

With this change we use the npm/yarn prepublishOnly hook to display and error and abort the process with a non zero error code when a user tries to publish an Ivy version of the package.

More info: https://docs.npmjs.com/misc/scripts