### PR TITLE
feat: adds an option to chose library entry module type

### DIFF
--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -83,6 +83,7 @@ export class NgEntryPoint {
       fesm5: pathJoinWithDest('fesm5', `${flatModuleFile}.js`),
       umd: pathJoinWithDest('bundles', `${flatModuleFile}.umd.js`),
       umdMinified: pathJoinWithDest('bundles', `${flatModuleFile}.umd.min.js`),
+      module: pathJoinWithDest(this.module, `${flatModuleFile}.js`),
     };
   }
 
@@ -102,6 +103,10 @@ export class NgEntryPoint {
 
   public get entryFile(): SourceFilePath {
     return this.$get('lib.entryFile');
+  }
+
+  public get module(): string {
+    return this.$get('lib.module') || "fesm5";
   }
 
   public get cssUrl(): CssUrl {

--- a/src/lib/ng-package-format/shared.ts
+++ b/src/lib/ng-package-format/shared.ts
@@ -32,4 +32,6 @@ export interface DestinationFiles {
   umd: string;
   /** Absolute path of this entry point `UMD` Minifief bundle */
   umdMinified: string;
+  /** Absolute path of this entry point prefered module */
+  module: string;
 }

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -45,7 +45,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
     ngPackage,
     {
       main: relativeUnixFromDestPath(destinationFiles.umd),
-      module: relativeUnixFromDestPath(destinationFiles.fesm5),
+      module: relativeUnixFromDestPath(destinationFiles.module),
       es2015: relativeUnixFromDestPath(destinationFiles.fesm2015),
       esm5: relativeUnixFromDestPath(destinationFiles.esm5),
       esm2015: relativeUnixFromDestPath(destinationFiles.esm2015),

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -84,6 +84,16 @@
         "umdId": {
           "description": "ID for the UMD bundle. By default, uses a value derived from the entry point's module ID (i.e., name property in package.json)",
           "type": "string"
+        },
+        "module": {
+          "description": "Preferred library entry module type. By default, uses fesm5",
+          "type": "string",
+          "enum": [
+            "fesm5",
+            "fesm2015",
+            "esm5",
+            "esm2015"
+          ]
         }
       }
     }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

This PR introduces a new option in ng-packagr.json to let the user chose which entry module type is preferred for the built library.
For example, it allow users to set esm5 module (instead of the default fesm5) in the built library's package.json "module" property which makes the library treeshakable when used somewhere else.

### How to use?
Simply add a "module" option in the "lib" property of ng-package.json file
Example ng-package.json:
`{
  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
  "dest": "../../dist/my-lib",
  "lib": {
    "entryFile": "src/public-api.ts",
    **"module": "esm5"**
  }
}`

The possible values for the module property are "fesm5", "fesm2015", "esm5", "esm2015" as mentionned in the ng-package schema.

This PR can help for this issue: #1318 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

This PR does not introduce any breaking change since the "module" property is optional and defaults to fesm5 as it is currently.
