### PR TITLE
feat: adds an option to choose library entry module type

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Create one `package.json` per npm package, run _ng-packagr_ for each!
 - [Embed Assets in CSS](docs/embed-assets-css.md)
 - [Managing Dependencies](docs/dependencies.md)
 - [Change the Entry File of a Library](docs/entry-file.md)
+- [Change the Library's Module type](docs/module-type.md)
 - [Change Configuration Locations](docs/configuration-locations.md)
 - [Override tsconfig](docs/override-tsconfig.md)
 - [Add Style Include Paths](docs/style-include-paths.md)

--- a/docs/module-type.md
+++ b/docs/module-type.md
@@ -1,0 +1,45 @@
+# Define Library's Module Type
+
+## Why?
+
+By default, the generated library's package.json `module` property points to the fesm5 bundle which is sometimes not treeshakable.
+
+You might want the `module` property of your library's package.json to point to the esm5 bundle for example.
+
+The same logic can be applied for `es2015` property if you want to point to esm2015 module instead of the default fesm2015.
+
+## How?
+
+### ES5 modules
+You can easily achieve this by adding a `module` property in the ng-package.json under lib:
+``` json
+{
+    "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+    "dest": "../../dist/my-lib",
+    "lib": {
+      "entryFile": "src/public-api.ts",
+      "module": "esm5"
+    }
+}
+```
+
+Possible values for the module property are: 
+- fesm5 (default)
+- esm5
+
+### ES2015 modules
+You can easily achieve this by adding a `es2015` property in the ng-package.json under lib:
+``` json
+{
+    "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+    "dest": "../../dist/my-lib",
+    "lib": {
+      "entryFile": "src/public-api.ts",
+      "es2015": "esm2015"
+    }
+}
+```
+
+Possible values for the module property are: 
+- fesm2015 (default)
+- esm2015

--- a/src/lib/ng-package/entry-point/entry-point.ts
+++ b/src/lib/ng-package/entry-point/entry-point.ts
@@ -20,6 +20,10 @@ export interface DestinationFiles {
   umd: string;
   /** Absolute path of this entry point `UMD` Minifief bundle */
   umdMinified: string;
+  /** Absolute path of this entry point preferred es5 module */
+  module: string;
+  /** Absolute path of this entry point preferred es2015 module */
+  es2015: string;
 }
 
 /**
@@ -103,6 +107,8 @@ export class NgEntryPoint {
       fesm5: pathJoinWithDest('fesm5', `${flatModuleFile}.js`),
       umd: pathJoinWithDest('bundles', `${flatModuleFile}.umd.js`),
       umdMinified: pathJoinWithDest('bundles', `${flatModuleFile}.umd.min.js`),
+      module: pathJoinWithDest(this.module, `${flatModuleFile}.js`),
+      es2015: pathJoinWithDest(this.es2015, `${flatModuleFile}.js`),
     };
   }
 
@@ -122,6 +128,14 @@ export class NgEntryPoint {
 
   public get entryFile(): string {
     return this.$get('lib.entryFile');
+  }
+
+  public get module(): string {
+    return this.$get('lib.module') || 'fesm5';
+  }
+
+  public get es2015(): string {
+    return this.$get('lib.es2015') || 'fesm2015';
   }
 
   public get cssUrl(): CssUrl {

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -73,8 +73,8 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
     ngPackage,
     {
       main: relativeUnixFromDestPath(destinationFiles.umd),
-      module: relativeUnixFromDestPath(destinationFiles.fesm5),
-      es2015: relativeUnixFromDestPath(destinationFiles.fesm2015),
+      module: relativeUnixFromDestPath(destinationFiles.module),
+      es2015: relativeUnixFromDestPath(destinationFiles.es2015),
       esm5: relativeUnixFromDestPath(destinationFiles.esm5),
       esm2015: relativeUnixFromDestPath(destinationFiles.esm2015),
       fesm5: relativeUnixFromDestPath(destinationFiles.fesm5),

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -92,6 +92,22 @@
         "umdId": {
           "description": "ID for the UMD bundle. By default, uses a value derived from the entry point's module ID (i.e., name property in package.json)",
           "type": "string"
+        },
+        "module": {
+          "description": "Preferred library entry module type. By default, uses fesm5",
+          "type": "string",
+          "enum": [
+            "fesm5",
+            "esm5"
+          ]
+        },
+        "es2015": {
+          "description": "Preferred library entry module type. By default, uses fesm2015",
+          "type": "string",
+          "enum": [
+            "fesm2015",
+            "esm2015"
+          ]
         }
       }
     }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Description

This PR introduces a new option in ng-packagr.json to let the user decide which entry module type is preferred for the built library.
For example, it allows users to set esm5 module (instead of the default fesm5) in the built library's package.json "module" property which makes the library treeshakable when used somewhere else.

### How to use?
Simply add a "module" option in the "lib" property of ng-package.json file
Example ng-package.json:
```
{
    "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
    "dest": "../../dist/my-lib",
    "lib": {
      "entryFile": "src/public-api.ts",
      "module": "esm5"
    }
}
```

The possible values for the module property are "fesm5", "fesm2015", "esm5", "esm2015" as mentionned in the ng-package schema.

### Related issue
This PR can help for this issue: #1318 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

This PR does not introduce any breaking change since the "module" property is optional and defaults to fesm5 as it is currently.
