### PR TITLE
feat: added ability to blacklist package sections for removal in build

### DIFF
--- a/integration/samples/blacklist-package-sections/package.json
+++ b/integration/samples/blacklist-package-sections/package.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../../src/package.schema.json",
+  "name": "@sample/blacklist-package-sections",
+  "description": "A sample library with the blacklistPackageSections setting set",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/ng-packagr/ng-packagr.git",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/public_api.ts"
+    },
+    "blacklistedPackageSections": [
+      "version",
+      "testA",
+      "testC"
+    ]
+  },
+  "testA": {
+    "a": "1",
+    "b": "2",
+    "c": "3"
+  },
+  "testB": {
+    "i": "x",
+    "ii": "y",
+    "iii": "z"
+  }
+}

--- a/integration/samples/blacklist-package-sections/specs/package.ts
+++ b/integration/samples/blacklist-package-sections/specs/package.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+
+describe(`@sample/blacklist-package-sections`, () => {
+  describe(`package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = require('../dist/package.json');
+    });
+
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should not have ngPackage field`, () => {
+      expect(PACKAGE.ngPackage).to.be.undefined;
+    });
+
+    it(`should have a disallowed blacklisted field`, () => {
+      expect(PACKAGE.version).to.be.ok;
+    });
+
+    it(`should not have testA field`, () => {
+      expect(PACKAGE.testA).to.be.undefined;
+    });
+
+    it(`should have testB field`, () => {
+      expect(PACKAGE.testB).to.be.ok;
+    });
+
+    it(`should not have testC field`, () => {
+      expect(PACKAGE.testC).to.be.undefined;
+    });
+  });
+});

--- a/integration/samples/blacklist-package-sections/src/public_api.ts
+++ b/integration/samples/blacklist-package-sections/src/public_api.ts
@@ -1,0 +1,1 @@
+export const x = 'Hello World';

--- a/src/lib/ng-package-format/package.ts
+++ b/src/lib/ng-package-format/package.ts
@@ -74,6 +74,19 @@ export class NgPackage {
     return value.concat('tslib').filter((value, index, self) => self.indexOf(value) === index);
   }
 
+  public get blacklistedPackageSections(): string[] {
+    // XX: default array values from JSON schema not recognized
+    const defValue = [];
+    const value = (this.primary.$get('blacklistedPackageSections') as string[]) || defValue;
+
+    const isDisallowed = (value: string, disallowed: string[] = []) => disallowed.some(d => d === value);
+
+    // Always remove disallowed values, and dedupe
+    return value
+      .filter(value => !isDisallowed(value, ['name', 'version']))
+      .filter((value, index, self) => self.indexOf(value) === index);
+  }
+
   private absolutePathFromPrimary(key: string) {
     return path.resolve(this.basePath, this.primary.$get(key));
   }

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -117,6 +117,14 @@ async function writePackageJson(
     throw e;
   }
 
+  // Removes blacklisted sections from package.json after build
+  if (pkg.blacklistedPackageSections.length > 0) {
+    log.info(`Removing blacklisted sections in package.json`);
+    for (const section of pkg.blacklistedPackageSections) {
+      delete packageJson[section];
+    }
+  }
+
   // Removes scripts from package.json after build
   if (packageJson.scripts) {
     if (pkg.keepLifecycleScripts !== true) {

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -31,6 +31,14 @@
       },
       "default": ["tslib"]
     },
+    "blacklistedPackageSections": {
+      "description": "A list of sections to be removed from package.json.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
     "lib": {
       "description": "Description of the library's entry point.",
       "type": "object",


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[*] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [*] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [*] Tests for the changes have been added


## Description

Adds the feature requested in: #1395 

Adds the ability to blacklist sections in your package.json so that they're removed at build time. To use, add the `blacklistedPackageSections` value to your config object, and then include any sections from your package.json that you want to remove.

## Does this PR introduce a breaking change?

```
[ ] Yes
[*] No
```
