### PR TITLE
fix: support the ng-package.json in secondary entry points

### DIFF
--- a/docs/secondary-entrypoints.md
+++ b/docs/secondary-entrypoints.md
@@ -37,3 +37,8 @@ The contents of `my_package/testing/package.json` can be as simple as:
 No, that is not a typo. No name is required. No version is required.
 It's all handled for you by ng-packagr!
 When built, the primary entry point is imported by `import {..} from '@my/library'` and the secondary entry point with `import {..} from '@my/library/testing'`.
+
+### Alternative to `package.json`
+
+Alternatively, you could create `ng-package.json` instead of `package.json`.
+This is particularly useful in conjunction with `no-implicit-dependencies` TSLint rule, which will complain if `package.json` does not contain the dependencies used in the secondary entry point, which is misleading since all the dependencies should be mentioned in the primary `package.json`.

--- a/integration/samples/secondary/feature-d/feature-d.ts
+++ b/integration/samples/secondary/feature-d/feature-d.ts
@@ -1,0 +1,5 @@
+import { FEATURE_A } from '@sample/secondary/feature-a';
+import { FEATURE_B } from '@sample/secondary/feature-b';
+import { FEATURE_C } from '@sample/secondary/feature-c';
+
+export const FEATURE_D = `Feature D: ${FEATURE_A} ${FEATURE_B} ${FEATURE_C}`;

--- a/integration/samples/secondary/feature-d/ng-package.json
+++ b/integration/samples/secondary/feature-d/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../src/ng-package.schema.json",
+  "lib": {
+    "entryFile": "feature-d.ts"
+  }
+}

--- a/integration/samples/secondary/specs/ep-feature-d.ts
+++ b/integration/samples/secondary/specs/ep-feature-d.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+describe(`@sample/secondary/feature-d`, () => {
+  let PACKAGE;
+
+  before(() => {
+    PACKAGE = require('../dist/feature-d/package.json');
+  });
+
+  it(`should exist`, () => {
+    expect(PACKAGE).to.be.ok;
+  });
+
+  it(`should be named '@sample/secondary/feature-d'`, () => {
+    expect(PACKAGE['name']).to.equal('@sample/secondary/feature-d');
+  });
+
+  it(`should reference "main" bundle (UMD)`, () => {
+    expect(PACKAGE['main']).to.equal('../bundles/sample-secondary-feature-d.umd.js');
+  });
+
+  it(`should reference "module" bundle (FESM5)`, () => {
+    expect(PACKAGE['module']).to.equal('../fesm5/sample-secondary-feature-d.js');
+  });
+
+  it(`should reference "typings" files`, () => {
+    expect(PACKAGE['typings']).to.equal('sample-secondary-feature-d.d.ts');
+  });
+
+  it(`should reference "metadata" file`, () => {
+    expect(PACKAGE['metadata']).to.equal('sample-secondary-feature-d.metadata.json');
+  });
+});


### PR DESCRIPTION
Currently secondary entry points are breaking `no-implicit-dependencies` TSLint rule, because the
rule is checking for package.json files, which in secondary entry points are anyway just containing
`ngPackage` configuration. Adding the support for ng-package.json removes the need for package.json,
thus TSLint will look correctly in parent package.json file and act accordingly.

fix 1391

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Fixes: [1391](https://github.com/ng-packagr/ng-packagr/issues/1391)


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
