### PR TITLE
fix: re prioritize ngcc `propertiesToConsider` properties based

### DIFF
--- a/src/lib/ngc/ngcc-processor.ts
+++ b/src/lib/ngc/ngcc-processor.ts
@@ -53,7 +53,7 @@ export class NgccProcessor {
       basePath: this._nodeModulesDirectory,
       targetEntryPointPath: path.dirname(packageJsonPath),
       compileAllFormats: false,
-      propertiesToConsider: ['fesm2015', 'fesm5', 'es2015', 'esm2015', 'esm5', 'main', 'module'],
+      propertiesToConsider: ['es2015', 'browser', 'module', 'main'],
       createNewEntryPointFormats: true,
       logger: this._logger,
       pathMappings: this._pathMappings,


### PR DESCRIPTION
Re prioritize ngcc based on the CLI mainFields https://github.com/angular/angular-cli/blob/0d70565f9d80f1d765622eb8c8b2c3c701723599/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts#L68
