### PR TITLE
feat: add support to TypeScript 3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@angular/compiler": "^9.0.0-beta",
     "@angular/compiler-cli": "^9.0.0-beta",
     "tslib": "^1.9.0",
-    "typescript": ">=3.4 < 3.6"
+    "typescript": "^3.6.4"
   },
   "devDependencies": {
     "@angular/cdk": "^8.0.0",


### PR DESCRIPTION
BREAKING CHANGE:

TypeScript versions prior to 3.6.4 are no longer supported.no longer supported.


