### PR TITLE
refactor: remove less-plugin-npm-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Create one `package.json` per npm package, run _ng-packagr_ for each!
 * :surfer: Inlines Templates and Stylesheets
 * :sparkles: CSS Features
   * :camel: Runs [SCSS](http://sass-lang.com/guide) preprocessor, supporting the [relative `~` import syntax](https://github.com/webpack-contrib/sass-loader#imports) and custom include paths
-  * :elephant: Runs [less](http://lesscss.org/#getting-started) preprocessor, supports the relative `~` import syntax
   * :snake: Runs [Stylus](http://stylus-lang.com) preprocessor, resolves relative paths relative to ng-package.json
   * :monkey: Adds vendor-specific prefixes w/ [autoprefixer](https://github.com/postcss/autoprefixer#autoprefixer-) and [browserslist](https://github.com/ai/browserslist#queries) &mdash; just tell your desired `.browserslistrc`
   * :tiger: Embed assets data w/ [postcss-url](https://github.com/postcss/postcss-url#inline)

--- a/integration/samples/scss-paths/baz/baz component.less
+++ b/integration/samples/scss-paths/baz/baz component.less
@@ -1,5 +1,5 @@
 @import 'theme';
-@import '~less/test/less/debug/linenumbers';
+@import 'less/test/less/debug/linenumbers';
 
 .baz {
   .oom {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "glob": "^7.1.2",
     "injection-js": "^2.2.1",
     "less": "^3.10.3",
-    "less-plugin-npm-import": "^2.1.0",
     "node-sass-tilde-importer": "^1.0.0",
     "postcss": "^7.0.18",
     "postcss-url": "^8.0.0",

--- a/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
+++ b/src/lib/ng-v5/entry-point/resources/stylesheet-processor.ts
@@ -71,7 +71,7 @@ export class StylesheetProcessor {
 
       case '.less':
         // this is the only way I found to make LESS sync
-        let cmd = `node "${require.resolve('less/bin/lessc')}" "${filePath}" --less-plugin-npm-import="prefix=~" --js`;
+        let cmd = `node "${require.resolve('less/bin/lessc')}" "${filePath}" --js`;
         if (this.styleIncludePaths.length) {
           cmd += ` --include-path="${this.styleIncludePaths.join(':')}"`;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,14 +3180,6 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-less-plugin-npm-import@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/less-plugin-npm-import/-/less-plugin-npm-import-2.1.0.tgz#823e6986c93318a98171ca858848b6bead55bf3e"
-  integrity sha1-gj5phskzGKmBccqFiEi2vq1Vvz4=
-  dependencies:
-    promise "~7.0.1"
-    resolve "~1.1.6"
-
 less@^3.10.3:
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/less/-/less-3.10.3.tgz#417a0975d5eeecc52cff4bcfa3c09d35781e6792"
@@ -4364,13 +4356,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-promise@~7.0.1:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.0.4.tgz#363e84a4c36c8356b890fed62c91ce85d02ed539"
-  integrity sha1-Nj6EpMNsg1a4kP7WLJHOhdAu1Tk=
-  dependencies:
-    asap "~2.0.3"
-
 prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -4763,11 +4748,6 @@ resolve@^1.11.0, resolve@^1.11.1:
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
-
-resolve@~1.1.6:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 responselike@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION

BREAKING CHANGE: 

Remove usage of deprecated `less-plugin-npm-import`. In less v3 is supports node_modules resolutions by default.

Before
```css
@import '~module/less/linenumbers';
```

After
```css
@import 'module/less/linenumbers';
```