### PR TITLE
refactor: deprecate `languageLevel` and `jsx` options

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -83,6 +83,9 @@ export const initializeTsConfig = (defaultTsConfig: ng.ParsedConfiguration, entr
     let tsConfig: ng.ParsedConfiguration = JSON.parse(JSON.stringify(defaultTsConfig));
 
     let jsx = tsConfig.options.jsx;
+    if (entryPoint.jsxConfig) {
+      log.warn(`'jsx' option has been deprecated use a custom tsconfig instead.`);
+    }
     switch (entryPoint.jsxConfig) {
       case 'preserve':
         jsx = ts.JsxEmit.Preserve;
@@ -95,6 +98,10 @@ export const initializeTsConfig = (defaultTsConfig: ng.ParsedConfiguration, entr
         break;
       default:
         break;
+    }
+
+    if (entryPoint.languageLevel) {
+      log.warn(`'languageLevel' option has been deprecated use a custom tsconfig instead.`);
     }
 
     const overrideOptions: ng.CompilerOptions = {


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
