### PR TITLE
Ignore JSON files in tsickle processing

### DIFF
--- a/src/lib/ngc/create-emit-callback.ts
+++ b/src/lib/ngc/create-emit-callback.ts
@@ -44,7 +44,7 @@ export function createEmitCallback(options: api.CompilerOptions): api.TsEmitCall
       | 'transformDecorators'
       | 'transformTypesToClosure'
     > = {
-      shouldSkipTsickleProcessing: fileName => /\.d\.ts$/.test(fileName) || GENERATED_FILES.test(fileName),
+      shouldSkipTsickleProcessing: fileName => /\.(d\.ts|json)$/.test(fileName) || GENERATED_FILES.test(fileName),
       pathToModuleName: (_context, _importPath) => '',
       shouldIgnoreWarningsForPath: _filePath => false,
       fileNameToModuleId: fileName => fileName,


### PR DESCRIPTION
Otherwise they get a `/**` block comment with `@fileoverview added by tsickle`
prepended to them and rollup cannot `JSON.parse()` the file contents.

Fixes #325

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Ignore JSON files in tsickle processing so rollup won't fail when calling `JSON.parse()` on the file contents.

Fixes #325


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

WIP: I will edit the commit message to apply to the Conventional Commits syntax, and I will create a test. (I started this change from the GitHub editor.)