### PR TITLE
WIP: feat: support multiple typescript rootDirs

### DIFF
--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -32,9 +32,7 @@ export async function compileSourceFiles(
     moduleResolutionCache,
     stylesheetProcessor,
   );
-  if (declarationDir) {
-    tsCompilerHost = redirectWriteFileCompilerHost(tsCompilerHost, tsConfigOptions.basePath, declarationDir);
-  }
+  tsCompilerHost = redirectWriteFileCompilerHost(tsCompilerHost, tsConfigOptions, declarationDir);
 
   if (tsConfigOptions.enableIvy && ngccProcessor) {
     tsCompilerHost = ngccTransformCompilerHost(tsCompilerHost, tsConfigOptions, ngccProcessor, moduleResolutionCache);

--- a/src/lib/ts/redirect-write-file-compiler-host.ts
+++ b/src/lib/ts/redirect-write-file-compiler-host.ts
@@ -1,18 +1,49 @@
 import * as ts from 'typescript';
+import * as ng from '@angular/compiler-cli';
 import * as path from 'path';
 
-/**
- * Returns a TypeScript compiler host that redirects `writeFile` output to the given `declarationDir`.
- *
- * @param compilerHost Original compiler host
- * @param baseDir Project base directory
- * @param declarationDir Declarations target directory
- */
-export function redirectWriteFileCompilerHost(
+function redirectWriteFileCompilerHostSingleRoot(
   compilerHost: ts.CompilerHost,
-  baseDir: string,
-  declarationDir: string,
-): ts.CompilerHost {
+  compilerOptions: ng.CompilerOptions,
+  declarationDir?: string,
+) {
+  return {
+    ...compilerHost,
+    writeFile: (
+      fileName: string,
+      data: string,
+      writeByteOrderMark: boolean,
+      onError?: (message: string) => void,
+      sourceFiles?: ReadonlyArray<ts.SourceFile>,
+    ) => {
+      let filePath = fileName;
+      if (declarationDir && /(\.d\.ts|\.metadata\.json)$/.test(fileName)) {
+        const projectRelativePath = path.relative(compilerOptions.basePath, fileName);
+        filePath = path.resolve(declarationDir, projectRelativePath);
+      }
+      compilerHost.writeFile.call(this, filePath, data, writeByteOrderMark, onError, sourceFiles);
+    },
+  };
+}
+
+function redirectWriteFileCompilerHostMultiRoot(
+  compilerHost: ts.CompilerHost,
+  compilerOptions: ng.CompilerOptions,
+  declarationDir?: string,
+) {
+  const baseDir = process.cwd();
+  const relativeRoots = compilerOptions.rootDirs.map(fileName => path.relative(baseDir, fileName));
+
+  const toOutputDir = (base, fileName, outDir) => {
+    let projectRelativePath = path.relative(base, fileName);
+    const relativeRoot = relativeRoots.find(path => projectRelativePath.startsWith(path));
+    if (relativeRoot) {
+      projectRelativePath = path.relative(relativeRoot, projectRelativePath);
+    }
+
+    return path.resolve(outDir, projectRelativePath);
+  };
+
   return {
     ...compilerHost,
     writeFile: (
@@ -24,10 +55,33 @@ export function redirectWriteFileCompilerHost(
     ) => {
       let filePath = fileName;
       if (/(\.d\.ts|\.metadata\.json)$/.test(fileName)) {
-        const projectRelativePath = path.relative(baseDir, fileName);
-        filePath = path.resolve(declarationDir, projectRelativePath);
+        filePath = toOutputDir(
+          compilerOptions.basePath,
+          fileName,
+          declarationDir ? declarationDir : compilerOptions.outDir,
+        );
+      } else {
+        filePath = toOutputDir(compilerOptions.outDir, fileName, compilerOptions.outDir);
       }
       compilerHost.writeFile.call(this, filePath, data, writeByteOrderMark, onError, sourceFiles);
     },
   };
+}
+
+/**
+ * Returns a TypeScript compiler host that redirects `writeFile` output to the given `declarationDir`.
+ *
+ * @param compilerHost Original compiler host
+ * @param baseDir Project base directory
+ * @param declarationDir Declarations target directory
+ */
+export function redirectWriteFileCompilerHost(
+  compilerHost: ts.CompilerHost,
+  compilerOptions: ng.CompilerOptions,
+  declarationDir?: string,
+): ts.CompilerHost {
+  if (compilerOptions.rootDirs) {
+    return redirectWriteFileCompilerHostMultiRoot(compilerHost, compilerOptions, declarationDir);
+  }
+  return redirectWriteFileCompilerHostSingleRoot(compilerHost, compilerOptions, declarationDir);
 }

--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -108,12 +108,17 @@ export const initializeTsConfig = (defaultTsConfig: ng.ParsedConfiguration, entr
       flatModuleId: entryPoint.moduleId,
       flatModuleOutFile: `${entryPoint.flatModuleFile}.js`,
       basePath,
-      rootDir: basePath,
       lib: entryPoint.languageLevel ? entryPoint.languageLevel.map(lib => `lib.${lib}.d.ts`) : tsConfig.options.lib,
       declarationDir: basePath,
       sourceRoot: `ng://${entryPoint.moduleId}`,
       jsx,
     };
+
+    if (tsConfig.options.rootDirs) {
+      overrideOptions.rootDirs = [...new Set([basePath, ...(tsConfig.options.rootDirs || [])])];
+    } else {
+      overrideOptions.rootDir = basePath;
+    }
 
     tsConfig.rootNames = [entryPoint.entryFilePath];
     tsConfig.options = { ...tsConfig.options, ...overrideOptions };


### PR DESCRIPTION
See #1333

## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

This adds support for `rootDirs` array in `tsconfig.json`.

This is a work in progress becase:
* handling everything with rootDirs only breaks the triple slash references for unknown reasons
* tests not yet implemented


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
