### PR TITLE
fix: replace ivy warning link to point to v9 instead of next

### DIFF
--- a/src/lib/ng-package/entry-point/init-tsconfig.transform.ts
+++ b/src/lib/ng-package/entry-point/init-tsconfig.transform.ts
@@ -15,7 +15,7 @@ export const initTsConfigTransformFactory = (defaultTsConfig: ParsedConfiguratio
       const ivyMsg =
         '******************************************************************************\n' +
         'It is not recommended to publish Ivy libraries to NPM repositories.\n' +
-        'Read more here: https://next.angular.io/guide/ivy#maintaining-library-compatibility\n' +
+        'Read more here: https://v9.angular.io/guide/ivy#maintaining-library-compatibility\n' +
         '******************************************************************************';
 
       msg(chalk.yellow(ivyMsg));


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
