### PR TITLE
fix: handle union type with a nullable argument

### DIFF
--- a/src/lib/ts/ctor-parameters.ts
+++ b/src/lib/ts/ctor-parameters.ts
@@ -169,6 +169,12 @@ function typeReferenceToExpression(
     case ts.SyntaxKind.NumberKeyword:
     case ts.SyntaxKind.NumericLiteral:
       return ts.createIdentifier('Number');
+    case ts.SyntaxKind.UnionType:
+      const childTypeNodes = (node as ts.UnionTypeNode).types.filter(t => t.kind !== ts.SyntaxKind.NullKeyword);
+
+      return childTypeNodes.length === 1
+        ? typeReferenceToExpression(entityNameToExpression, childTypeNodes[0], typeChecker)
+        : undefined;
     case ts.SyntaxKind.TypeReference:
       const typeRef = node as ts.TypeReferenceNode;
       let typeSymbol = typeChecker.getSymbolAtLocation(typeRef.typeName);


### PR DESCRIPTION
Currently constructor parameters with union types that contains nullable argument are not being converted properly and result in broken behaviour.

With this change we align the ctor-parameters downlevel transformer to be closer to the NGTSC reflector: https://github.com/angular/angular/blob/master/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts#L65-L66

More info: https://github.com/angular/angular-cli/pull/17077
