### PR TITLE
docs: add example ng-package.json file to secondary-entrypoints.md

### DIFF
--- a/docs/secondary-entrypoints.md
+++ b/docs/secondary-entrypoints.md
@@ -41,4 +41,13 @@ When built, the primary entry point is imported by `import {..} from '@my/librar
 ### Alternative to `package.json`
 
 Alternatively, you could create `ng-package.json` instead of `package.json`.
-This is particularly useful in conjunction with `no-implicit-dependencies` TSLint rule, which will complain if `package.json` does not contain the dependencies used in the secondary entry point, which is misleading since all the dependencies should be mentioned in the primary `package.json`.
+This is particularly useful in conjunction with `no-implicit-dependencies` TSLint rule, which will complain if `package.json` does not contain the dependencies used in the secondary entry point, which is misleading since all the dependencies should be mentioned in the primary `package.json`. If you're using `ng-package.json`, use the same format as your other ng-package.json files, i.e.:
+
+```json
+{
+    "$schema": "node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "./src/public_api.ts"
+    }
+}
+```


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Adding documentation for the secondary-entrypoints stuff. I tried just changing the package.json I created to be an ng-package.json but it gave me build errors when I did so. I wanted to add some clarification to the docs. If this doesn't cut it please let me know! I'd love to change it :grin:

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
