### PR TITLE
fix: auto add tslib as direct dependency

### DIFF
--- a/integration/samples/apf/specs/package.ts
+++ b/integration/samples/apf/specs/package.ts
@@ -15,8 +15,8 @@ describe(`@sample/apf`, () => {
       expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
     });
 
-    it(`should have 'tslib' as a peerDependencies`, () => {
-      expect(PACKAGE.peerDependencies.tslib).to.be.ok;
+    it(`should have 'tslib' as a direct dependencies`, () => {
+      expect(PACKAGE.dependencies.tslib).to.be.ok;
     });
 
     it(`should not have ngPackage field`, () => {
@@ -74,8 +74,8 @@ describe(`@sample/apf`, () => {
       PACKAGE = require('../dist/secondary/package.json');
     });
 
-    it(`should not have 'tslib' as a peerDependencies`, () => {
-      expect(PACKAGE.peerDependencies && PACKAGE.peerDependencies.tslib).to.be.undefined;
+    it(`should not have 'tslib' as a dependencies`, () => {
+      expect(PACKAGE.dependencies && PACKAGE.dependencies.tslib).to.be.undefined;
     });
 
     it(`should exist`, () => {

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -10,7 +10,7 @@ import { globFiles } from '../../utils/glob';
 import { EntryPointNode, isEntryPointInProgress, isPackage, PackageNode } from '../nodes';
 import { copyFile } from '../../utils/copy';
 
-export const writePackageTransform: Transform = transformFromPromise(async graph => {
+export const writePackageTransform: Transform = transformFromPromise(async (graph) => {
   const entryPoint = graph.find(isEntryPointInProgress()) as EntryPointNode;
   const ngEntryPoint: NgEntryPoint = entryPoint.data.entryPoint;
   const ngPackageNode = graph.find(isPackage) as PackageNode;
@@ -34,7 +34,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
     // COPY SOURCE FILES TO DESTINATION
     log.info('Copying declaration files');
     await Promise.all(
-      declarationFiles.map(value => {
+      declarationFiles.map((value) => {
         const relativePath = path.relative(ngEntryPoint.entryFilePath, value);
         const destination = path.resolve(destinationFiles.declarations, relativePath);
         return copyFile(value, destination, { overwrite: true, dereference: true });
@@ -42,7 +42,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
     );
   }
   if (ngPackage.assets.length && !ngEntryPoint.isSecondaryEntryPoint) {
-    const assets = ngPackage.assets.map(x => path.join(ngPackage.src, x));
+    const assets = ngPackage.assets.map((x) => path.join(ngPackage.src, x));
     const assetFiles = await globFiles(assets, {
       ignore: ignorePaths,
       cache: ngPackageNode.cache.globCache,
@@ -52,7 +52,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
       // COPY ASSET FILES TO DESTINATION
       log.info('Copying assets');
       await Promise.all(
-        assetFiles.map(value => {
+        assetFiles.map((value) => {
           const relativePath = path.relative(ngPackage.src, value);
           const destination = path.resolve(ngPackage.dest, relativePath);
           return copyFile(value, destination, { overwrite: true, dereference: true });
@@ -123,28 +123,32 @@ async function writePackageJson(
   // version at least matches that of angular if we use require('tslib').version
   // it will get what installed and not the minimum version nor if it is a `~` or `^`
   // this is only required for primary
-  if (
-    !entryPoint.isSecondaryEntryPoint &&
-    !(packageJson.peerDependencies && packageJson.peerDependencies.tslib) &&
-    !(packageJson.dependencies && packageJson.dependencies.tslib)
-  ) {
-    const {
-      peerDependencies: angularPeerDependencies = {},
-      dependencies: angularDependencies = {},
-    } = require('@angular/compiler/package.json');
-    const tsLibVersion = angularPeerDependencies.tslib || angularDependencies.tslib;
+  if (!entryPoint.isSecondaryEntryPoint) {
+    if (!packageJson.peerDependencies?.tslib && !packageJson.dependencies?.tslib) {
+      const {
+        peerDependencies: angularPeerDependencies = {},
+        dependencies: angularDependencies = {},
+      } = require('@angular/compiler/package.json');
+      const tsLibVersion = angularPeerDependencies.tslib || angularDependencies.tslib;
 
-    if (tsLibVersion) {
-      packageJson.peerDependencies = {
-        ...packageJson.peerDependencies,
-        tslib: tsLibVersion,
+      if (tsLibVersion) {
+        packageJson.dependencies = {
+          ...packageJson.dependencies,
+          tslib: tsLibVersion,
+        };
+      }
+    } else if (packageJson.peerDependencies?.tslib) {
+      log.warn(`'tslib' is no longer recommanded to be used as a 'peerDependencies'. Moving it to 'dependencies'.`);
+      packageJson.dependencies = {
+        ...(packageJson.dependencies || {}),
+        tslib: packageJson.peerDependencies.tslib,
       };
     }
   }
 
   // Verify non-peerDependencies as they can easily lead to duplicate installs or version conflicts
   // in the node_modules folder of an application
-  const whitelist = pkg.whitelistedNonPeerDependencies.map(value => new RegExp(value));
+  const whitelist = pkg.whitelistedNonPeerDependencies.map((value) => new RegExp(value));
   try {
     checkNonPeerDependencies(packageJson, 'dependencies', whitelist);
   } catch (e) {
@@ -210,7 +214,7 @@ function checkNonPeerDependencies(packageJson: Record<string, unknown>, property
   }
 
   for (const dep of Object.keys(packageJson[property])) {
-    if (whitelist.find(regex => regex.test(dep))) {
+    if (whitelist.find((regex) => regex.test(dep))) {
       log.debug(`Dependency ${dep} is whitelisted in '${property}'`);
     } else {
       log.warn(


### PR DESCRIPTION
Tslib version is bound to the TypeScript version used to comopile the library. Thus, we shouldn't list`tslib` as a  `peerDependencies`. This is because, a user can install libraries which have been compiled with older versions of TypeScript and thus require multiple `tslib` versions to be installed.

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
