### PR TITLE
feat: embed assets in css file using data uri by default

### DIFF
--- a/integration/samples/custom/ng-package.json
+++ b/integration/samples/custom/ng-package.json
@@ -2,6 +2,7 @@
   "$schema": "../../../src/ng-package.schema.json",
   "keepLifecycleScripts": true,
   "lib": {
-    "entryFile": "src/public_api.ts"
+    "entryFile": "src/public_api.ts",
+    "cssUrl": "none"
   }
 }

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -63,7 +63,7 @@
           "description": "Embed assets in css file using data URIs - see https://css-tricks.com/data-uris",
           "type": "string",
           "enum": ["none", "inline"],
-          "default": "none"
+          "default": "inline"
         },
         "styleIncludePaths": {
           "description": "Any additional paths that should be used to resolve style imports",


### PR DESCRIPTION
BREAKING CHANGE:

`cssUrl` option default value has been changed to `inline`
More info about this option can be found: https://github.com/ng-packagr/ng-packagr/blob/master/docs/embed-assets-css.md
