### PR TITLE
test(integration): added sample integration for lazy loading

### DIFF
--- a/integration/samples/lazy-loading/README.md
+++ b/integration/samples/lazy-loading/README.md
@@ -1,0 +1,3 @@
+# Sample library: Lazy loading
+
+Library testing Angular Lazy Loading

--- a/integration/samples/lazy-loading/ng-package.json
+++ b/integration/samples/lazy-loading/ng-package.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../src/ng-package.schema.json",
+    "dest": "dest",
+    "lib": {
+        "entryFile": "src/index.ts"
+    }
+}

--- a/integration/samples/lazy-loading/package.json
+++ b/integration/samples/lazy-loading/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "lazy-loading"
+}

--- a/integration/samples/lazy-loading/src/index.ts
+++ b/integration/samples/lazy-loading/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./lib/lazy.module";

--- a/integration/samples/lazy-loading/src/lib/index.ts
+++ b/integration/samples/lazy-loading/src/lib/index.ts
@@ -1,0 +1,1 @@
+export {LazyModule} from "./lazymodule.module";

--- a/integration/samples/lazy-loading/src/lib/index.ts
+++ b/integration/samples/lazy-loading/src/lib/index.ts
@@ -1,1 +1,0 @@
-export {LazyModule} from "./lazymodule.module";

--- a/integration/samples/lazy-loading/src/lib/lazy.module.ts
+++ b/integration/samples/lazy-loading/src/lib/lazy.module.ts
@@ -1,0 +1,18 @@
+import {NgModule} from "@angular/core";
+import {RouterModule, Routes} from "@angular/router";
+
+const routes: Routes = [
+    {
+        path: "example",
+        loadChildren: () =>
+            import("./lazy.routing.module").then(
+                (m) => m.LazyRoutingModule
+            ),
+    },
+];
+
+@NgModule({
+    imports: [RouterModule.forChild(routes)],
+    providers: [],
+})
+export class LazyModule {}

--- a/integration/samples/lazy-loading/src/lib/lazy.routing.module.ts
+++ b/integration/samples/lazy-loading/src/lib/lazy.routing.module.ts
@@ -1,0 +1,22 @@
+import {NgModule} from "@angular/core";
+import {RouterModule, Routes} from "@angular/router";
+
+import {ComponentPage} from "./pages/component";
+
+const routes: Routes = [
+    {
+        path: "example",
+        component: ComponentPage,
+    }
+];
+
+@NgModule({
+    declarations: [
+        ComponentPage,
+    ],
+    imports: [
+        RouterModule.forChild(routes),
+    ],
+    providers: [],
+})
+export class LazyRoutingModule {}

--- a/integration/samples/lazy-loading/src/lib/pages/component.ts
+++ b/integration/samples/lazy-loading/src/lib/pages/component.ts
@@ -1,0 +1,8 @@
+import {Component} from "@angular/core";
+
+@Component({
+    selector: "component",
+    template: "<div>it works!</div>",
+})
+export class ComponentPage {
+}


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[X] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description

This PR adds a new integration sample for lazy loading. At the moment, it fails with the following error
```
ERROR: /Users/user/ng-packagr/integration/samples/lazy-loading/src/lib/lazy.module.ts:14:1: Error encountered in metadata generated for exported symbol 'LazyModule': 
 /Users/user/ng-packagr/integration/samples/lazy-loading/src/lib/lazy.module.ts:7:23: Metadata collected contains an error that will be reported at runtime: Lambda not supported.
  {"__symbolic":"error","message":"Lambda not supported","line":6,"character":22}
```

This PR allows a reproduction of an issue described here: https://github.com/ng-packagr/ng-packagr/issues/1708

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

