### PR TITLE
fix: use unaltered scripts when `keepLifecycleScripts` is enabled

### DIFF
--- a/integration/samples/custom/package.json
+++ b/integration/samples/custom/package.json
@@ -9,6 +9,7 @@
     "@angular/common": "^4.1.3"
   },
   "scripts": {
+    "prepublishOnly": "node -e 'console.log(\"Performing prepublishOnly checks...\");'",
     "test": "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
   }
 }


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix ?!?
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

It is common for packages to have a `prepublish` or a `prepublishOnly` script, something like `scripts/prepublish.js` from this repository. This PR updates `writePackageJson` to not replace an existing `prepublishOnly` script when the `keepLifecycleScripts` flag is provided.

~~And I've also added a commit that replaced all Unicode non-breaking spaces (`U+00A0`) with actual spaces, since the NBSPs aren't really needed in those cases.~~ Move to another PR.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
