### PR TITLE
chore: remove redundant param

### DIFF
--- a/src/lib/ng-package/discover-packages.ts
+++ b/src/lib/ng-package/discover-packages.ts
@@ -131,20 +131,20 @@ async function findSecondaryPackagesPaths(directoryPath: string, excludeFolder: 
 /**
  * Reads a secondary entry point from it's package file.
  *
- * @param primaryDirectoryPath A path pointing to the directory of the primary entry point.
  * @param primary The primary entry point.
+ * @param userPackage The user package for the secondary entry point.
  */
 function secondaryEntryPoint(
-  primaryDirectoryPath: string,
   primary: NgEntryPoint,
-  { packageJson, ngPackageJson, basePath }: UserPackage,
+  userPackage: UserPackage,
 ): NgEntryPoint {
-  if (path.resolve(basePath) === path.resolve(primaryDirectoryPath)) {
+  const { packageJson, ngPackageJson, basePath } = userPackage;
+  if (path.resolve(basePath) === path.resolve(primary.basePath)) {
     log.error(`Cannot read secondary entry point. It's already a primary entry point. Path: ${basePath}`);
     throw new Error(`Secondary entry point is already a primary.`);
   }
 
-  const relativeSourcePath = path.relative(primaryDirectoryPath, basePath);
+  const relativeSourcePath = path.relative(primary.basePath, basePath);
   const secondaryModuleId = ensureUnixPath(`${primary.moduleId}/${relativeSourcePath}`);
 
   return new NgEntryPoint(packageJson, ngPackageJson, basePath, {
@@ -167,7 +167,7 @@ export async function discoverPackages({ project }: { project: string }): Promis
   for (const folderPath of folderPaths) {
     const secondaryPackage = await resolveUserPackage(folderPath, true);
     if (secondaryPackage) {
-      secondaries.push(secondaryEntryPoint(basePath, primary, secondaryPackage));
+      secondaries.push(secondaryEntryPoint(primary, secondaryPackage));
     }
   }
 

--- a/src/lib/ng-package/entry-point/entry-point.ts
+++ b/src/lib/ng-package/entry-point/entry-point.ts
@@ -50,7 +50,7 @@ export interface DestinationFiles {
 export class NgEntryPoint {
   constructor(
     /** Values from the `package.json` file of this entry point. */
-    public readonly packageJson: any,
+    public readonly packageJson: Record<string, any>,
     /** Values from either the `ngPackage` option (from `package.json`) or values from `ng-package.json`. */
     public readonly ngPackageJson: NgPackageConfig,
     /** Absolute directory path of this entry point's `package.json` location. */


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

The `secondaryEntryPoint()` receives the basePath information twice: once as a parameter and once as information on the primary entry point, I removed the parameter.

I've also went ahead and updated the `UserPackage` interface to have stricter types and added an extra check for the `package.json` configuration.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
