### PR TITLE
refactor: deprecate keepLifecycleScripts in favor of keepPackageScripts

### DIFF
--- a/integration/samples/custom/package.json
+++ b/integration/samples/custom/package.json
@@ -9,6 +9,7 @@
     "@angular/common": "^4.1.3"
   },
   "scripts": {
+    "prepublishOnly": "node -e 'console.log(\"Performing prepublishOnly checks...\");'",
     "test": "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
   }
 }

--- a/integration/samples/ivy/ng-packagr-config.js
+++ b/integration/samples/ivy/ng-packagr-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  keepPackageScripts: true,
   lib: {
     entryFile: 'public_api.ts',
   },

--- a/integration/samples/ivy/package.json
+++ b/integration/samples/ivy/package.json
@@ -11,6 +11,7 @@
     "zone.js": "^0.8.4"
   },
   "scripts": {
+    "prepublishOnly": "node -e 'console.log(\"Performing prepublishOnly checks...\");'",
     "test":
       "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
   }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "postbuild": "node ./scripts/postbuild.js",
     "schema": "json2ts --input src/ng-package.schema.json --output src/ng-package.schema.ts",
     "release": "standard-version --releaseCommitMessageFormat 'release: cut v{{currentTag}}' --no-verify",
+    "postinstall": "yarn schema",
     "publish:ci": "yarn build",
     "integration:samples": "integration/samples.sh",
     "integration:samples:dev": "ts-node --project src/tsconfig.packagr.json ./integration/samples.dev.ts",

--- a/src/lib/ng-package/discover-packages.ts
+++ b/src/lib/ng-package/discover-packages.ts
@@ -1,5 +1,6 @@
 import { parse as parseJson } from 'jsonc-parser';
 import * as path from 'path';
+import { NgPackageConfig } from "../../ng-package.schema";
 import * as log from '../utils/log';
 import { ensureUnixPath } from '../utils/path';
 import { NgEntryPoint } from './entry-point/entry-point';
@@ -12,7 +13,7 @@ interface UserPackage {
   /** Values from the `package.json` file of this user package. */
   packageJson: Record<string, any>;
   /** NgPackageConfig for this user package. */
-  ngPackageJson: Record<string, any>;
+  ngPackageJson: NgPackageConfig;
   /** Absolute directory path of this user package. */
   basePath: string;
 }

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -195,21 +195,23 @@ async function writePackageJson(
 
   // Removes scripts from package.json after build
   if (packageJson.scripts) {
-    if (pkg.keepLifecycleScripts !== true) {
-      spinner.info(`Removing scripts section in package.json as it's considered a potential security vulnerability.`);
-      delete packageJson.scripts;
+    if (pkg.keepPackageScripts || pkg.keepLifecycleScripts) {
+      const npmPublishInfo = `The package.json file contains 'scripts', they are considered a potential security vulnerability if published to NPM.`;
+      const flagInfo = pkg.keepLifecycleScripts
+        ? `Unset 'keepLifecycleScripts' to remove the 'scripts' section from package.json.`
+        : `Unset 'keepPackageScripts' to remove the 'scripts' section from package.json.`;
+      spinner.warn(colors.yellow(npmPublishInfo + '\n' + flagInfo));
     } else {
-      spinner.warn(
-        colors.yellow(
-          `You enabled keepLifecycleScripts explicitly. The scripts section in package.json will be published to npm.`,
-        ),
+      spinner.info(
+        `Removing existing 'scripts' section from package.json as it's considered a potential security vulnerability.`
       );
+      delete packageJson.scripts;
     }
   }
 
   if (isIvy && !entryPoint.isSecondaryEntryPoint && compilationMode !== 'partial') {
-    const scripts = packageJson.scripts || (packageJson.scripts = {});
-    scripts.prepublishOnly =
+    packageJson.scripts = packageJson.scripts || {};
+    packageJson.scripts.prepublishOnly =
       'node --eval "console.error(\'' +
       'ERROR: Trying to publish a package that has been compiled by Ivy in full compilation mode. This is not allowed.\\n' +
       'Please delete and rebuild the package with Ivy partial compilation mode, before attempting to publish.\\n' +

--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -63,6 +63,11 @@ export class NgPackage {
   public get keepLifecycleScripts(): boolean {
     return this.primary.$get('keepLifecycleScripts') === true;
   }
+
+  public get keepPackageScripts(): boolean {
+    return this.primary.$get('keepPackageScripts') === true;
+  }
+
   public get assets(): string[] {
     return this.primary.$get('assets');
   }

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -19,6 +19,12 @@
       "default": "dist"
     },
     "keepLifecycleScripts": {
+      "description": "A deprecated alias for 'keepPackageScripts'.",
+      "type": "boolean",
+      "default": false,
+      "x-deprecated": "Use 'keepPackageScripts' option instead."
+    },
+    "keepPackageScripts": {
       "description": "Enable this to keep the 'scripts' section in package.json. Read the NPM Blog on 'Package install scripts vulnerability' – http://blog.npmjs.org/post/141702881055/package-install-scripts-vulnerability",
       "type": "boolean",
       "default": false


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Deprecated the `keepLifecycleScripts` flag in favor of a better named flag: `keepPackageScripts`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
