### PR TITLE
test: add tests for all APF secondary entry points

### DIFF
--- a/integration/samples/apf/specs/package.ts
+++ b/integration/samples/apf/specs/package.ts
@@ -11,6 +11,14 @@ describe(`@sample/apf`, () => {
       expect(PACKAGE).to.be.ok;
     });
 
+    it(`should be named '@sample/apf'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/apf');
+    });
+
+    it(`should not have ngPackage field`, () => {
+      expect(PACKAGE.ngPackage).to.be.undefined;
+    });
+
     it(`should not have 'prepublishOnly' script`, () => {
       expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
     });
@@ -19,40 +27,18 @@ describe(`@sample/apf`, () => {
       expect(PACKAGE.dependencies.tslib).to.be.ok;
     });
 
-    it(`should not have ngPackage field`, () => {
-      expect(PACKAGE.ngPackage).to.be.undefined;
-    });
-
-    it(`should be named '@sample/apf'`, () => {
-      expect(PACKAGE['name']).to.equal('@sample/apf');
-    });
-
-    it(`should reference "main" bundle (UMD)`, () => {
-      expect(PACKAGE['main']).to.equal('bundles/sample-apf.umd.js');
-    });
-
-    it(`should reference "module" bundle (fesm2015)`, () => {
-      expect(PACKAGE['module']).to.equal('fesm2015/sample-apf.js');
-    });
-
-    it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('fesm2015/sample-apf.js');
-    });
-
-    it(`should reference "esm2015" file`, () => {
-      expect(PACKAGE['esm2015']).to.equal('esm2015/sample-apf.js');
-    });
-
-    it(`should reference "fesm2015" file`, () => {
-      expect(PACKAGE['fesm2015']).to.equal('fesm2015/sample-apf.js');
-    });
-
-    it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('sample-apf.d.ts');
-    });
-
-    it(`should reference "metadata" file`, () => {
-      expect(PACKAGE['metadata']).to.equal('sample-apf.metadata.json');
+    Object.entries({
+      main: 'bundles/sample-apf.umd.js',
+      module: 'fesm2015/sample-apf.js',
+      es2015: 'fesm2015/sample-apf.js',
+      esm2015: 'esm2015/sample-apf.js',
+      fesm2015: 'fesm2015/sample-apf.js',
+      typings: 'sample-apf.d.ts',
+      metadata: 'sample-apf.metadata.json',
+    }).forEach(([key, value]: [string, string]): void => {
+      it(`should reference "${key}" file`, () => {
+        expect(PACKAGE[key]).to.equal(value);
+      });
     });
 
     it(`should apply the 'sideEffects: false' flag by default`, () => {
@@ -66,52 +52,128 @@ describe(`@sample/apf`, () => {
       PACKAGE = require('../dist/secondary/package.json');
     });
 
-    it(`should not have 'tslib' as a dependencies`, () => {
-      expect(PACKAGE.dependencies && PACKAGE.dependencies.tslib).to.be.undefined;
-    });
-
     it(`should exist`, () => {
       expect(PACKAGE).to.be.ok;
-    });
-
-    it(`should not have 'prepublishOnly' script`, () => {
-      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
-    });
-
-    it(`should not have ngPackage field`, () => {
-      expect(PACKAGE.ngPackage).to.be.undefined;
     });
 
     it(`should be named '@sample/apf/secondary'`, () => {
       expect(PACKAGE['name']).to.equal('@sample/apf/secondary');
     });
 
-    it(`should reference "main" bundle (UMD)`, () => {
-      expect(PACKAGE['main']).to.equal('../bundles/sample-apf-secondary.umd.js');
+    it(`should not have ngPackage field`, () => {
+      expect(PACKAGE.ngPackage).to.be.undefined;
     });
 
-    it(`should reference "module" bundle (fesm2015)`, () => {
-      expect(PACKAGE['module']).to.equal('../fesm2015/sample-apf-secondary.js');
+    it(`should not have 'prepublishOnly' script`, () => {
+      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
     });
 
-    it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('../fesm2015/sample-apf-secondary.js');
+    it(`should not have 'tslib' as a dependencies`, () => {
+      expect(PACKAGE.dependencies && PACKAGE.dependencies.tslib).to.be.undefined;
     });
 
-    it(`should reference "esm2015" file`, () => {
-      expect(PACKAGE['esm2015']).to.equal('../esm2015/secondary/sample-apf-secondary.js');
+    Object.entries({
+      main: '../bundles/sample-apf-secondary.umd.js',
+      module: '../fesm2015/sample-apf-secondary.js',
+      es2015: '../fesm2015/sample-apf-secondary.js',
+      esm2015: '../esm2015/secondary/sample-apf-secondary.js',
+      fesm2015: '../fesm2015/sample-apf-secondary.js',
+      typings: 'sample-apf-secondary.d.ts',
+      metadata: 'sample-apf-secondary.metadata.json',
+    }).forEach(([key, value]: [string, string]): void => {
+      it(`should reference "${key}" file`, () => {
+        expect(PACKAGE[key]).to.equal(value);
+      });
     });
 
-    it(`should reference "fesm2015" file`, () => {
-      expect(PACKAGE['fesm2015']).to.equal('../fesm2015/sample-apf-secondary.js');
+    it(`should apply the 'sideEffects: false' flag by default`, () => {
+      expect(PACKAGE['sideEffects']).to.be.false;
+    });
+  });
+
+  describe(`secondary/testing/package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = require('../dist/secondary/testing/package.json');
     });
 
-    it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('sample-apf-secondary.d.ts');
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
     });
 
-    it(`should reference "metadata" file`, () => {
-      expect(PACKAGE['metadata']).to.equal('sample-apf-secondary.metadata.json');
+    it(`should be named '@sample/apf/secondary/testing'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/apf/secondary/testing');
+    });
+
+    it(`should not have ngPackage field`, () => {
+      expect(PACKAGE.ngPackage).to.be.undefined;
+    });
+
+    it(`should not have 'prepublishOnly' script`, () => {
+      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
+    });
+
+    it(`should not have 'tslib' as a dependencies`, () => {
+      expect(PACKAGE.dependencies && PACKAGE.dependencies.tslib).to.be.undefined;
+    });
+
+    Object.entries({
+      main: '../../bundles/sample-apf-secondary-testing.umd.js',
+      module: '../../fesm2015/sample-apf-secondary-testing.js',
+      es2015: '../../fesm2015/sample-apf-secondary-testing.js',
+      esm2015: '../../esm2015/secondary/testing/sample-apf-secondary-testing.js',
+      fesm2015: '../../fesm2015/sample-apf-secondary-testing.js',
+      typings: 'sample-apf-secondary-testing.d.ts',
+      metadata: 'sample-apf-secondary-testing.metadata.json',
+    }).forEach(([key, value]: [string, string]): void => {
+      it(`should reference "${key}" file`, () => {
+        expect(PACKAGE[key]).to.equal(value);
+      });
+    });
+
+    it(`should apply the 'sideEffects: false' flag by default`, () => {
+      expect(PACKAGE['sideEffects']).to.be.false;
+    });
+  });
+
+  describe(`testing/package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = require('../dist/testing/package.json');
+    });
+
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should be named '@sample/apf/testing'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/apf/testing');
+    });
+
+    it(`should not have ngPackage field`, () => {
+      expect(PACKAGE.ngPackage).to.be.undefined;
+    });
+
+    it(`should not have 'prepublishOnly' script`, () => {
+      expect(PACKAGE.scripts && PACKAGE.scripts.prepublishOnly).to.be.undefined;
+    });
+
+    it(`should not have 'tslib' as a dependencies`, () => {
+      expect(PACKAGE.dependencies && PACKAGE.dependencies.tslib).to.be.undefined;
+    });
+
+    Object.entries({
+      main: '../bundles/sample-apf-testing.umd.js',
+      module: '../fesm2015/sample-apf-testing.js',
+      es2015: '../fesm2015/sample-apf-testing.js',
+      esm2015: '../esm2015/testing/sample-apf-testing.js',
+      fesm2015: '../fesm2015/sample-apf-testing.js',
+      typings: 'sample-apf-testing.d.ts',
+      metadata: 'sample-apf-testing.metadata.json',
+    }).forEach(([key, value]: [string, string]): void => {
+      it(`should reference "${key}" file`, () => {
+        expect(PACKAGE[key]).to.equal(value);
+      });
     });
 
     it(`should apply the 'sideEffects: false' flag by default`, () => {


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests ~for the changes~ have been added


## Description

Added `package.json` value tests to cover all entry points for `integration/samples/apf`, including `@sample/apf/secondary/testing`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
