### PR TITLE
refactor: use data from parent entry point

### DIFF
--- a/src/lib/ng-package/discover-packages.ts
+++ b/src/lib/ng-package/discover-packages.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import * as log from '../utils/log';
-import { ensureUnixPath } from '../utils/path';
 import { NgEntryPoint } from './entry-point/entry-point';
 import { NgPackage } from './package';
 import { globFiles } from '../utils/glob';
@@ -115,15 +114,7 @@ function secondaryEntryPoint(primary: NgEntryPoint, userPackage: UserPackage): N
     log.error(`Cannot read secondary entry point. It's already a primary entry point. Path: ${basePath}`);
     throw new Error(`Secondary entry point is already a primary.`);
   }
-
-  const relativeSourcePath = path.relative(primary.basePath, basePath);
-  const secondaryModuleId = ensureUnixPath(`${primary.moduleId}/${relativeSourcePath}`);
-
-  return new NgEntryPoint(packageJson, ngPackageJson, basePath, {
-    moduleId: secondaryModuleId,
-    primaryDestinationPath: primary.destinationPath,
-    destinationPath: path.join(primary.destinationPath, relativeSourcePath),
-  });
+  return new NgEntryPoint(packageJson, ngPackageJson, basePath, primary);
 }
 
 export async function discoverPackages({ project }: { project: string }): Promise<NgPackage> {

--- a/src/lib/ng-package/entry-point/entry-point.spec.ts
+++ b/src/lib/ng-package/entry-point/entry-point.spec.ts
@@ -4,8 +4,8 @@ import { NgPackageConfig } from '../../../ng-package.schema';
 import { NgEntryPoint } from './entry-point';
 
 describe(`NgEntryPoint`, () => {
-  const testDestinationPath = '/example/entry-point/dest'
-  const testSourcePath = '/example/entry-point/src'
+  const testSourcePath: string = resolve('/example/entry-point/src');
+  const testDestinationPath: string = resolve('/example/entry-point/dest');
   let primaryEntryPoint: NgEntryPoint;
   let secondaryEntryPoint: NgEntryPoint;
   let packageJson: Record<string, any>;
@@ -31,9 +31,10 @@ describe(`NgEntryPoint`, () => {
     expect(primaryEntryPoint.basePath).to.equal(testSourcePath);
 
     // Test readonly getters:
-    expect(primaryEntryPoint.entryFilePath).to.equal(resolve(testSourcePath, 'public-api.ts'));
+    expect(primaryEntryPoint.entryFilePath).to.equal(join(testSourcePath, 'public-api.ts'));
     expect(primaryEntryPoint.isSecondaryEntryPoint).to.be.false;
-    expect(primaryEntryPoint.destinationPath).to.equal(resolve(testDestinationPath));
+    expect(primaryEntryPoint.destinationPath).to.equal(testDestinationPath);
+    expect(primaryEntryPoint.libraryDestinationPath).to.equal(testDestinationPath);
     expect(Object.keys(primaryEntryPoint.destinationFiles).length).to.equal(6);
     expect(primaryEntryPoint.entryFile).to.equal('public-api.ts');
     expect(primaryEntryPoint.cssUrl).to.be.undefined;  // TODO: should default to 'inline'.
@@ -72,12 +73,12 @@ describe(`NgEntryPoint`, () => {
     };
     primaryEntryPoint = new NgEntryPoint(packageJson, primaryNgPackageJson, testSourcePath);
 
-    expect(primaryEntryPoint.entryFilePath).to.equal(resolve(testSourcePath, 'test-api.ts'));
+    expect(primaryEntryPoint.entryFilePath).to.equal(join(testSourcePath, 'test-api.ts'));
     expect(primaryEntryPoint.entryFile).to.equal('test-api.ts');
     expect(primaryEntryPoint.cssUrl).to.equal('inline');
     expect(Object.entries(primaryEntryPoint.umdModuleIds)).to.deep.equal([['@example/test-module', 'example.testModule']]);
     expect(primaryEntryPoint.flatModuleFile).to.equal('exampleTestEntryPoint');
-    expect(primaryEntryPoint.styleIncludePaths).to.deep.equal([resolve(testSourcePath, './style-includes')]);
+    expect(primaryEntryPoint.styleIncludePaths).to.deep.equal([join(testSourcePath, './style-includes')]);
     expect(primaryEntryPoint.umdId).to.equal('example.testEntryPoint');
     expect(primaryEntryPoint.amdId).to.equal('@example/testEntryPoint');
     expect(primaryEntryPoint.sideEffects).to.be.true;
@@ -101,17 +102,19 @@ describe(`NgEntryPoint`, () => {
       },
     };
     const secondaryEntryPointRelativeSourcePath = 'extra';
-    const secondaryEntryPointBasePath = join(testSourcePath, secondaryEntryPointRelativeSourcePath);
+    const secondaryEntryPointSourcePath = join(testSourcePath, secondaryEntryPointRelativeSourcePath);
+    const secondaryEntryPointDestinationPath = join(testDestinationPath, secondaryEntryPointRelativeSourcePath);
     secondaryData = {
       moduleId: `@example/test-entry-point/${ secondaryEntryPointRelativeSourcePath }`,
       primaryDestinationPath: primaryEntryPoint.destinationPath,
       destinationPath: join(primaryEntryPoint.destinationPath, secondaryEntryPointRelativeSourcePath),
     };
-    secondaryEntryPoint = new NgEntryPoint(packageJson, secondaryNgPackageJson, secondaryEntryPointBasePath, secondaryData);
+    secondaryEntryPoint = new NgEntryPoint(packageJson, secondaryNgPackageJson, secondaryEntryPointSourcePath, secondaryData);
 
-    expect(secondaryEntryPoint.entryFilePath).to.equal(resolve(secondaryEntryPointBasePath, 'public-api.ts'));
+    expect(secondaryEntryPoint.entryFilePath).to.equal(join(secondaryEntryPointSourcePath, 'public-api.ts'));
     expect(secondaryEntryPoint.isSecondaryEntryPoint).to.be.true;
-    expect(secondaryEntryPoint.destinationPath).to.equal(resolve(secondaryData.destinationPath));
+    expect(secondaryEntryPoint.destinationPath).to.equal(secondaryEntryPointDestinationPath);
+    expect(secondaryEntryPoint.libraryDestinationPath).to.equal(testDestinationPath);
     expect(Object.keys(secondaryEntryPoint.destinationFiles).length).to.equal(6);
     expect(secondaryEntryPoint.entryFile).to.equal('public-api.ts');
     expect(secondaryEntryPoint.cssUrl).to.be.undefined;  // TODO: should default to 'inline'.
@@ -159,12 +162,12 @@ describe(`NgEntryPoint`, () => {
     };
     secondaryEntryPoint = new NgEntryPoint(packageJson, secondaryNgPackageJson, secondaryEntryPointBasePath, secondaryData);
 
-    expect(secondaryEntryPoint.entryFilePath).to.equal(resolve(secondaryEntryPointBasePath, 'demo-api.ts'));
+    expect(secondaryEntryPoint.entryFilePath).to.equal(join(secondaryEntryPointBasePath, 'demo-api.ts'));
     expect(secondaryEntryPoint.entryFile).to.equal('demo-api.ts');
     expect(secondaryEntryPoint.cssUrl).to.equal('none');
     expect(Object.entries(secondaryEntryPoint.umdModuleIds)).to.deep.equal([['@example/test-module/extra', 'example.testModuleExtra']]);
     expect(secondaryEntryPoint.flatModuleFile).to.equal('exampleTestEntryPointExtra');
-    expect(secondaryEntryPoint.styleIncludePaths).to.deep.equal([resolve(secondaryEntryPointBasePath, './style-includes')]);
+    expect(secondaryEntryPoint.styleIncludePaths).to.deep.equal([join(secondaryEntryPointBasePath, './style-includes')]);
     expect(secondaryEntryPoint.umdId).to.equal('example.testEntryPointExtra');
     expect(secondaryEntryPoint.amdId).to.equal('@example/testEntryPointExtra');
     expect(secondaryEntryPoint.sideEffects).to.be.true;

--- a/src/lib/ng-package/entry-point/entry-point.spec.ts
+++ b/src/lib/ng-package/entry-point/entry-point.spec.ts
@@ -11,7 +11,6 @@ describe(`NgEntryPoint`, () => {
   let packageJson: Record<string, any>;
   let primaryNgPackageJson: NgPackageConfig;
   let secondaryNgPackageJson: NgPackageConfig;
-  let secondaryData: Record<string, any>;
 
   it(`check primary entry point defaults`, () => {
     packageJson = {
@@ -37,7 +36,7 @@ describe(`NgEntryPoint`, () => {
     expect(primaryEntryPoint.libraryDestinationPath).to.equal(testDestinationPath);
     expect(Object.keys(primaryEntryPoint.destinationFiles).length).to.equal(6);
     expect(primaryEntryPoint.entryFile).to.equal('public-api.ts');
-    expect(primaryEntryPoint.cssUrl).to.be.undefined;  // TODO: should default to 'inline'.
+    expect(primaryEntryPoint.cssUrl).to.be.undefined; // TODO: should default to 'inline'.
     expect(primaryEntryPoint.umdModuleIds).to.be.undefined;
     expect(primaryEntryPoint.flatModuleFile).to.equal('example-test-entry-point');
     expect(primaryEntryPoint.styleIncludePaths).to.be.empty;
@@ -50,7 +49,6 @@ describe(`NgEntryPoint`, () => {
     expect(primaryEntryPoint.$get('lib.entryFile')).to.equal('public-api.ts');
     expect(primaryEntryPoint.$get('lib.NO_SUCH_PROPERTY')).to.be.undefined;
   });
-
 
   it(`check primary entry point overrides`, () => {
     packageJson = {
@@ -76,14 +74,15 @@ describe(`NgEntryPoint`, () => {
     expect(primaryEntryPoint.entryFilePath).to.equal(join(testSourcePath, 'test-api.ts'));
     expect(primaryEntryPoint.entryFile).to.equal('test-api.ts');
     expect(primaryEntryPoint.cssUrl).to.equal('inline');
-    expect(Object.entries(primaryEntryPoint.umdModuleIds)).to.deep.equal([['@example/test-module', 'example.testModule']]);
+    expect(Object.entries(primaryEntryPoint.umdModuleIds)).to.deep.equal([
+      ['@example/test-module', 'example.testModule'],
+    ]);
     expect(primaryEntryPoint.flatModuleFile).to.equal('exampleTestEntryPoint');
     expect(primaryEntryPoint.styleIncludePaths).to.deep.equal([join(testSourcePath, './style-includes')]);
     expect(primaryEntryPoint.umdId).to.equal('example.testEntryPoint');
     expect(primaryEntryPoint.amdId).to.equal('@example/testEntryPoint');
     expect(primaryEntryPoint.sideEffects).to.be.true;
   });
-
 
   it(`check secondary entry point defaults`, () => {
     packageJson = {
@@ -104,12 +103,12 @@ describe(`NgEntryPoint`, () => {
     const secondaryEntryPointRelativeSourcePath = 'extra';
     const secondaryEntryPointSourcePath = join(testSourcePath, secondaryEntryPointRelativeSourcePath);
     const secondaryEntryPointDestinationPath = join(testDestinationPath, secondaryEntryPointRelativeSourcePath);
-    secondaryData = {
-      moduleId: `@example/test-entry-point/${ secondaryEntryPointRelativeSourcePath }`,
-      primaryDestinationPath: primaryEntryPoint.destinationPath,
-      destinationPath: join(primaryEntryPoint.destinationPath, secondaryEntryPointRelativeSourcePath),
-    };
-    secondaryEntryPoint = new NgEntryPoint(packageJson, secondaryNgPackageJson, secondaryEntryPointSourcePath, secondaryData);
+    secondaryEntryPoint = new NgEntryPoint(
+      packageJson,
+      secondaryNgPackageJson,
+      secondaryEntryPointSourcePath,
+      primaryEntryPoint,
+    );
 
     expect(secondaryEntryPoint.entryFilePath).to.equal(join(secondaryEntryPointSourcePath, 'public-api.ts'));
     expect(secondaryEntryPoint.isSecondaryEntryPoint).to.be.true;
@@ -117,7 +116,7 @@ describe(`NgEntryPoint`, () => {
     expect(secondaryEntryPoint.libraryDestinationPath).to.equal(testDestinationPath);
     expect(Object.keys(secondaryEntryPoint.destinationFiles).length).to.equal(6);
     expect(secondaryEntryPoint.entryFile).to.equal('public-api.ts');
-    expect(secondaryEntryPoint.cssUrl).to.be.undefined;  // TODO: should default to 'inline'.
+    expect(secondaryEntryPoint.cssUrl).to.be.undefined; // TODO: should default to 'inline'.
     expect(secondaryEntryPoint.umdModuleIds).to.be.undefined;
     expect(secondaryEntryPoint.flatModuleFile).to.equal('example-test-entry-point-extra');
     expect(secondaryEntryPoint.styleIncludePaths).to.be.empty;
@@ -155,22 +154,25 @@ describe(`NgEntryPoint`, () => {
     };
     const secondaryEntryPointRelativeSourcePath = 'extra';
     const secondaryEntryPointBasePath = join(testSourcePath, secondaryEntryPointRelativeSourcePath);
-    secondaryData = {
-      moduleId: `@example/test-entry-point/${ secondaryEntryPointRelativeSourcePath }`,
-      primaryDestinationPath: primaryEntryPoint.destinationPath,
-      destinationPath: join(primaryEntryPoint.destinationPath, secondaryEntryPointRelativeSourcePath),
-    };
-    secondaryEntryPoint = new NgEntryPoint(packageJson, secondaryNgPackageJson, secondaryEntryPointBasePath, secondaryData);
+    secondaryEntryPoint = new NgEntryPoint(
+      packageJson,
+      secondaryNgPackageJson,
+      secondaryEntryPointBasePath,
+      primaryEntryPoint,
+    );
 
     expect(secondaryEntryPoint.entryFilePath).to.equal(join(secondaryEntryPointBasePath, 'demo-api.ts'));
     expect(secondaryEntryPoint.entryFile).to.equal('demo-api.ts');
     expect(secondaryEntryPoint.cssUrl).to.equal('none');
-    expect(Object.entries(secondaryEntryPoint.umdModuleIds)).to.deep.equal([['@example/test-module/extra', 'example.testModuleExtra']]);
+    expect(Object.entries(secondaryEntryPoint.umdModuleIds)).to.deep.equal([
+      ['@example/test-module/extra', 'example.testModuleExtra'],
+    ]);
     expect(secondaryEntryPoint.flatModuleFile).to.equal('exampleTestEntryPointExtra');
-    expect(secondaryEntryPoint.styleIncludePaths).to.deep.equal([join(secondaryEntryPointBasePath, './style-includes')]);
+    expect(secondaryEntryPoint.styleIncludePaths).to.deep.equal([
+      join(secondaryEntryPointBasePath, './style-includes'),
+    ]);
     expect(secondaryEntryPoint.umdId).to.equal('example.testEntryPointExtra');
     expect(secondaryEntryPoint.amdId).to.equal('@example/testEntryPointExtra');
     expect(secondaryEntryPoint.sideEffects).to.be.true;
   });
-
 });

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -132,7 +132,10 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
  * flattened JavaScript bundles, type definitions, (...).
  *
  * @param entryPoint An entry point of an Angular package / library
+ * @param pkg The package for which the entry point is being built.
  * @param additionalProperties Additional properties, e.g. binary artefacts (bundle files), to merge into `package.json`
+ * @param isIvy Whether or not the build is an Ivy build.
+ * @param spinner A reference to the terminal spinner.
  */
 async function writePackageJson(
   entryPoint: NgEntryPoint,
@@ -177,16 +180,16 @@ async function writePackageJson(
 
       delete packageJson.peerDependencies.tslib;
     }
-  }
 
-  // Verify non-peerDependencies as they can easily lead to duplicate installs or version conflicts
-  // in the node_modules folder of an application
-  const whitelist = pkg.whitelistedNonPeerDependencies.map(value => new RegExp(value));
-  try {
-    checkNonPeerDependencies(packageJson, 'dependencies', whitelist, spinner);
-  } catch (e) {
-    await rimraf(entryPoint.destinationPath);
-    throw e;
+    // Verify non-peerDependencies as they can easily lead to duplicate installs or version conflicts
+    // in the node_modules folder of an application
+    const whitelist = pkg.whitelistedNonPeerDependencies.map(value => new RegExp(value));
+    try {
+      checkNonPeerDependencies(packageJson, 'dependencies', whitelist, spinner);
+    } catch (e) {
+      await rimraf(entryPoint.libraryDestinationPath);
+      throw e;
+    }
   }
 
   // Removes scripts from package.json after build


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

I have refactored the `NgEntryPoint` to make the API more clear:

* replaced the `secondaryData` NgEntryPoint parameter with a reference to the parent entry point
  https://github.com/ng-packagr/ng-packagr/blob/7dcbdf04a35a72b548c267d0b89708a7809036b8/src/lib/ng-package/entry-point/entry-point.ts#L58-L59
* add `NgEntryPoint.libraryDestinationPath`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
