### PR TITLE
refactor: use TypeScript generics for the Traversable BuildGraph

### DIFF
--- a/src/lib/ng-package/entry-point/analyse-sources.transform.ts
+++ b/src/lib/ng-package/entry-point/analyse-sources.transform.ts
@@ -10,8 +10,8 @@ import { ensureUnixPath } from '../../utils/path';
 
 export const analyseSourcesTransform: Transform = pipe(
   map(graph => {
-    const entryPoints = graph.filter(isEntryPoint) as EntryPointNode[];
-    const dirtyEntryPoints = entryPoints.filter(x => x.state !== 'done') as EntryPointNode[];
+    const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
+    const dirtyEntryPoints: EntryPointNode[] = entryPoints.filter(x => x.state !== 'done');
 
     for (const entryPoint of dirtyEntryPoints) {
       analyseEntryPoint(graph, entryPoint, entryPoints);
@@ -32,7 +32,7 @@ function analyseEntryPoint(graph: BuildGraph, entryPoint: EntryPointNode, entryP
   const { oldPrograms, analysesSourcesFileCache, moduleResolutionCache } = entryPoint.cache;
   const oldProgram = oldPrograms && (oldPrograms['analysis'] as ts.Program | undefined);
   const { moduleId } = entryPoint.data.entryPoint;
-  const packageNode = graph.find(isPackage) as PackageNode;
+  const packageNode: PackageNode = graph.find(isPackage);
   const primaryModuleId = packageNode.data.primary.moduleId;
 
   debug(`Analysing sources for ${moduleId}`);

--- a/src/lib/ng-package/entry-point/compile-ngc.transform.ts
+++ b/src/lib/ng-package/entry-point/compile-ngc.transform.ts
@@ -10,8 +10,8 @@ import { StylesheetProcessor } from '../../styles/stylesheet-processor';
 
 export const compileNgcTransform: Transform = transformFromPromise(async graph => {
   log.info(`Compiling TypeScript sources through ngc`);
-  const entryPoint = graph.find(isEntryPointInProgress()) as EntryPointNode;
-  const entryPoints = graph.filter(isEntryPoint) as EntryPointNode[];
+  const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
+  const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
   // Add paths mappings for dependencies
   const tsConfig = setDependenciesTsConfigPaths(entryPoint.data.tsConfig, entryPoints);
 

--- a/src/lib/ng-package/entry-point/init-tsconfig.transform.ts
+++ b/src/lib/ng-package/entry-point/init-tsconfig.transform.ts
@@ -8,7 +8,7 @@ import { msg } from '../../utils/log';
 export const initTsConfigTransformFactory = (defaultTsConfig: ParsedConfiguration): Transform =>
   transformFromPromise(async graph => {
     // Initialize tsconfig for each entry point
-    const entryPoints = graph.filter(isEntryPoint) as EntryPointNode[];
+    const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
     initializeTsConfig(defaultTsConfig, entryPoints);
 
     if (defaultTsConfig.options.enableIvy) {

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -10,7 +10,7 @@ import { rollupBundleFile } from '../../flatten/rollup';
 import { minifyJsFile } from '../../flatten/uglify';
 
 export const writeBundlesTransform: Transform = transformFromPromise(async graph => {
-  const entryPoint = graph.find(isEntryPointInProgress()) as EntryPointNode;
+  const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
   const { destinationFiles, entryPoint: ngEntryPoint, tsConfig } = entryPoint.data;
   const cache = entryPoint.cache;
 

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -11,9 +11,9 @@ import { EntryPointNode, isEntryPointInProgress, isPackage, PackageNode, fileUrl
 import { Node } from '../../graph/node';
 
 export const writePackageTransform: Transform = transformFromPromise(async graph => {
-  const entryPoint = graph.find(isEntryPointInProgress()) as EntryPointNode;
+  const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
   const ngEntryPoint: NgEntryPoint = entryPoint.data.entryPoint;
-  const ngPackageNode = graph.find(isPackage) as PackageNode;
+  const ngPackageNode: PackageNode = graph.find(isPackage);
   const ngPackage = ngPackageNode.data;
   const { destinationFiles } = entryPoint.data;
   const ignorePaths: string[] = [

--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -6,6 +6,7 @@ import { by, isInProgress, isDirty } from '../graph/select';
 import { NgEntryPoint, DestinationFiles } from './entry-point/entry-point';
 import { NgPackage } from './package';
 import { FileCache } from '../file-system/file-cache';
+import { ComplexPredicate } from '../graph/build-graph';
 
 export const TYPE_NG_PACKAGE = 'application/ng-package';
 export const TYPE_NG_ENTRY_POINT = 'application/ng-entry-point';
@@ -26,15 +27,15 @@ export function isPackage(node: Node): node is PackageNode {
   return node.type === TYPE_NG_PACKAGE;
 }
 
-export function byEntryPoint() {
+export function byEntryPoint(): ComplexPredicate<EntryPointNode> {
   return by(isEntryPoint);
 }
 
-export function isEntryPointInProgress() {
+export function isEntryPointInProgress(): ComplexPredicate<EntryPointNode> {
   return by(isEntryPoint).and(isInProgress);
 }
 
-export function isEntryPointDirty() {
+export function isEntryPointDirty(): ComplexPredicate<EntryPointNode> {
   return by(isEntryPoint).and(isDirty);
 }
 

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -20,7 +20,7 @@ export async function compileSourceFiles(
   log.debug(`ngc (v${ng.VERSION.full})`);
 
   const tsConfigOptions: ng.CompilerOptions = { ...tsConfig.options, ...extraOptions };
-  const entryPoint = graph.find(isEntryPointInProgress()) as EntryPointNode;
+  const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
 
   let tsCompilerHost = cacheCompilerHost(
     graph,


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Improves type safety for the BuildGraph.

Besides the type changes, only one extra type guard was added, but it should have no effect at runtime:
```
      const foundNode = graph.get(pkgUri);
      if (!isPackage(foundNode)) {
        return graph;
      }

      const ngPkg: PackageNode = foundNode;
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
