### PR TITLE
fix: sourcemap should not differ based on build path

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -87,7 +87,6 @@ export const initializeTsConfig = (defaultTsConfig: ng.ParsedConfiguration, entr
       flatModuleOutFile: `${entryPoint.flatModuleFile}.js`,
       basePath,
       rootDir: basePath,
-      sourceRoot: basePath,
     };
 
     tsConfig.rootNames = [entryPoint.entryFilePath];


### PR DESCRIPTION
When setting `sourceRoot` the inlined sourcemap will differ based on the physical location of the library when built.

Closes https://github.com/angular/angular-cli/issues/19335
