### PR TITLE
feat: add option to provide paths for the watcher to ignore

### DIFF
--- a/src/lib/ng-package/options.di.ts
+++ b/src/lib/ng-package/options.di.ts
@@ -4,6 +4,8 @@ export const OPTIONS_TOKEN = new InjectionToken<NgPackagrOptions>(`ng.v5.options
 export interface NgPackagrOptions {
   /** Whether or not ng-packagr will watch for file changes and perform an incremental build. */
   watch?: boolean;
+  /** Files to be ignored by that watcher so they don't trigger rebuilds  */
+  ignoredPaths?: (RegExp | string)[];
 }
 
 export const provideOptions = (options: NgPackagrOptions = {}): ValueProvider => ({

--- a/src/lib/ng-package/package.transform.ts
+++ b/src/lib/ng-package/package.transform.ts
@@ -125,7 +125,7 @@ export const packageTransformFactory = (
 
 const watchTransformFactory = (
   project: string,
-  _options: NgPackagrOptions,
+  options: NgPackagrOptions,
   analyseSourcesTransform: Transform,
   entryPointTransform: Transform,
 ) => (source$: Observable<BuildGraph>): Observable<BuildGraph> => {
@@ -136,7 +136,7 @@ const watchTransformFactory = (
   return source$.pipe(
     switchMap(graph => {
       const { data, cache } = graph.find(isPackage);
-      return createFileWatch(data.src, [data.dest]).pipe(
+      return createFileWatch(data.src, [data.dest, ...(options.ignoredPaths || [])]).pipe(
         tap(fileChange => {
           const { filePath, event } = fileChange;
           const { sourcesFileCache, ngccProcessingCache } = cache;

--- a/src/lib/packagr.ts
+++ b/src/lib/packagr.ts
@@ -98,8 +98,8 @@ export class NgPackagr {
    *
    * @return An observable result of the transformation pipeline.
    */
-  public watch(): Observable<void> {
-    this.providers.push(provideOptions({ watch: true }));
+  public watch(ignoredPaths: (RegExp | string)[] = []): Observable<void> {
+    this.providers.push(provideOptions({ watch: true, ignoredPaths }));
 
     return this.buildAsObservable();
   }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [] Tests for the changes have been added


## Description

Added the ability to provide custom `ignoredPaths` when setting up ngpackagr.

Closes https://github.com/ng-packagr/ng-packagr/issues/1829


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
