### PR TITLE
feat: enable customizing Stylesheet Processor through dependency injection

### DIFF
--- a/src/lib/ng-package/entry-point/compile-ngc.di.ts
+++ b/src/lib/ng-package/entry-point/compile-ngc.di.ts
@@ -1,11 +1,15 @@
-import { InjectionToken } from 'injection-js';
+import { InjectionToken, Provider } from 'injection-js';
 import { Transform } from '../../graph/transform';
 import { TransformProvider, provideTransform } from '../../graph/transform.di';
-import { compileNgcTransform } from './compile-ngc.transform';
+import { compileNgcTransformFactory } from './compile-ngc.transform';
+import { STYLESHEET_PROCESSOR_TOKEN, STYLESHEET_PROCESSOR } from '../../styles/stylesheet-processor.di';
 
 export const COMPILE_NGC_TOKEN = new InjectionToken<Transform>(`ng.v5.compileNgcTransform`);
 
 export const COMPILE_NGC_TRANSFORM: TransformProvider = provideTransform({
   provide: COMPILE_NGC_TOKEN,
-  useFactory: () => compileNgcTransform,
+  useFactory: compileNgcTransformFactory,
+  deps: [STYLESHEET_PROCESSOR_TOKEN],
 });
+
+export const COMPILE_NGC_PROVIDERS: Provider[] = [STYLESHEET_PROCESSOR, COMPILE_NGC_TRANSFORM];

--- a/src/lib/ng-package/entry-point/compile-ngc.transform.ts
+++ b/src/lib/ng-package/entry-point/compile-ngc.transform.ts
@@ -6,11 +6,9 @@ import { compileSourceFiles } from '../../ngc/compile-source-files';
 import { NgccProcessor } from '../../ngc/ngcc-processor';
 import { setDependenciesTsConfigPaths } from '../../ts/tsconfig';
 import { isEntryPointInProgress, EntryPointNode, isEntryPoint } from '../nodes';
-import { StylesheetProcessor } from '../../styles/stylesheet-processor';
+import { StylesheetProcessor as StylesheetProcessorClass } from '../../styles/stylesheet-processor';
 
-export const compileNgcTransformFactory = (StylesheetProcessor: {
-  new (...args: any[]): StylesheetProcessor;
-}): Transform => {
+export const compileNgcTransformFactory = (StylesheetProcessor: typeof StylesheetProcessorClass): Transform => {
   return transformFromPromise(async graph => {
     const spinner = ora({
       hideCursor: false,

--- a/src/lib/ng-package/entry-point/compile-ngc.transform.ts
+++ b/src/lib/ng-package/entry-point/compile-ngc.transform.ts
@@ -8,51 +8,55 @@ import { setDependenciesTsConfigPaths } from '../../ts/tsconfig';
 import { isEntryPointInProgress, EntryPointNode, isEntryPoint } from '../nodes';
 import { StylesheetProcessor } from '../../styles/stylesheet-processor';
 
-export const compileNgcTransform: Transform = transformFromPromise(async graph => {
-  const spinner = ora({
-    hideCursor: false,
-    discardStdin: false,
-  }).start(`Compiling TypeScript sources through NGC`);
+export const compileNgcTransformFactory = (StylesheetProcessor: {
+  new (...args: any[]): StylesheetProcessor;
+}): Transform => {
+  return transformFromPromise(async graph => {
+    const spinner = ora({
+      hideCursor: false,
+      discardStdin: false,
+    }).start(`Compiling TypeScript sources through NGC`);
 
-  try {
-    const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
-    const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
-    // Add paths mappings for dependencies
-    const tsConfig = setDependenciesTsConfigPaths(entryPoint.data.tsConfig, entryPoints);
+    try {
+      const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
+      const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
+      // Add paths mappings for dependencies
+      const tsConfig = setDependenciesTsConfigPaths(entryPoint.data.tsConfig, entryPoints);
 
-    // Compile TypeScript sources
-    const { esm2015, declarations } = entryPoint.data.destinationFiles;
-    const { moduleResolutionCache, ngccProcessingCache } = entryPoint.cache;
-    const { basePath, cssUrl, styleIncludePaths } = entryPoint.data.entryPoint;
-    const stylesheetProcessor = new StylesheetProcessor(basePath, cssUrl, styleIncludePaths);
+      // Compile TypeScript sources
+      const { esm2015, declarations } = entryPoint.data.destinationFiles;
+      const { moduleResolutionCache, ngccProcessingCache } = entryPoint.cache;
+      const { basePath, cssUrl, styleIncludePaths } = entryPoint.data.entryPoint;
+      const stylesheetProcessor = new StylesheetProcessor(basePath, cssUrl, styleIncludePaths);
 
-    const ngccProcessor = tsConfig.options.enableIvy
-      ? new NgccProcessor(ngccProcessingCache, tsConfig.project, tsConfig.options, entryPoints)
-      : undefined;
+      const ngccProcessor = tsConfig.options.enableIvy
+        ? new NgccProcessor(ngccProcessingCache, tsConfig.project, tsConfig.options, entryPoints)
+        : undefined;
 
-    if (ngccProcessor && !entryPoint.data.entryPoint.isSecondaryEntryPoint) {
-      // Only run the async version of NGCC during the primary entrypoint processing.
-      ngccProcessor.process();
+      if (ngccProcessor && !entryPoint.data.entryPoint.isSecondaryEntryPoint) {
+        // Only run the async version of NGCC during the primary entrypoint processing.
+        ngccProcessor.process();
+      }
+
+      await compileSourceFiles(
+        graph,
+        tsConfig,
+        moduleResolutionCache,
+        stylesheetProcessor,
+        {
+          outDir: path.dirname(esm2015),
+          declarationDir: path.dirname(declarations),
+          declaration: true,
+          target: ts.ScriptTarget.ES2015,
+        },
+        ngccProcessor,
+      );
+    } catch (error) {
+      spinner.fail();
+      throw error;
     }
 
-    await compileSourceFiles(
-      graph,
-      tsConfig,
-      moduleResolutionCache,
-      stylesheetProcessor,
-      {
-        outDir: path.dirname(esm2015),
-        declarationDir: path.dirname(declarations),
-        declaration: true,
-        target: ts.ScriptTarget.ES2015,
-      },
-      ngccProcessor,
-    );
-  } catch (error) {
-    spinner.fail();
-    throw error;
-  }
-
-  spinner.succeed();
-  return graph;
-});
+    spinner.succeed();
+    return graph;
+  });
+};

--- a/src/lib/ng-package/entry-point/entry-point.di.ts
+++ b/src/lib/ng-package/entry-point/entry-point.di.ts
@@ -1,7 +1,7 @@
 import { InjectionToken, Provider } from 'injection-js';
 import { Transform } from '../../graph/transform';
 import { TransformProvider, provideTransform } from '../../graph/transform.di';
-import { COMPILE_NGC_TOKEN, COMPILE_NGC_TRANSFORM } from './compile-ngc.di';
+import { COMPILE_NGC_TOKEN, COMPILE_NGC_PROVIDERS } from './compile-ngc.di';
 import { WRITE_BUNDLES_TRANSFORM, WRITE_BUNDLES_TRANSFORM_TOKEN } from './write-bundles.di';
 import { WRITE_PACKAGE_TRANSFORM, WRITE_PACKAGE_TRANSFORM_TOKEN } from './write-package.di';
 import { entryPointTransformFactory } from './entry-point.transform';
@@ -16,7 +16,7 @@ export const ENTRY_POINT_TRANSFORM: TransformProvider = provideTransform({
 
 export const ENTRY_POINT_PROVIDERS: Provider[] = [
   ENTRY_POINT_TRANSFORM,
-  COMPILE_NGC_TRANSFORM,
+  ...COMPILE_NGC_PROVIDERS,
   WRITE_BUNDLES_TRANSFORM,
   WRITE_PACKAGE_TRANSFORM,
 ];

--- a/src/lib/styles/stylesheet-processor.di.ts
+++ b/src/lib/styles/stylesheet-processor.di.ts
@@ -1,0 +1,10 @@
+import { FactoryProvider, InjectionToken } from 'injection-js';
+import { StylesheetProcessor } from './stylesheet-processor';
+
+export const STYLESHEET_PROCESSOR_TOKEN = new InjectionToken<StylesheetProcessor>(`ng.v5.stylesheetProcessor`);
+
+export const STYLESHEET_PROCESSOR: FactoryProvider = {
+  provide: STYLESHEET_PROCESSOR_TOKEN,
+  useFactory: () => StylesheetProcessor,
+  deps: [],
+};


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description
Add a feature customizing `StylesheetProcessor` through dependency injection.
Future usage example:

```ts
export class MyStylesheetProcessor extends StylesheetProcessor {
  process(filePath: string, content: string) {
    // pre compile scripts
    console.debug('content:', content);

    return super.process(filePath, content);
  }
}

const packager = ngPackagr();

packager.withProviders([{
  provide: STYLESHEET_PROCESSOR_TOKEN,
  useFactory: () => MyStylesheetProcessor,
  deps: [],
}]);
```

This will enable users to transform stylesheets before compiled. 
I can get a lot of flexibility about compiling stylesheets.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
