### PR TITLE
test: use POSIX compatible code for building integration samples

### DIFF
--- a/integration/samples.sh
+++ b/integration/samples.sh
@@ -1,37 +1,63 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+# NOTE: When making changes, make sure to run the script through ShellCheck!
+# @see https://github.com/koalaman/shellcheck
 
-FIND_COMMAND=""
+# Exit script on error.
+set -o errexit
+# Disable pathname expansion.
+set -o noglob
+# Error on unset (non-special) parameter expansion.
+set -o nounset
 
-if [[ $OSTYPE == "win32" ]]; then
-    FIND_COMMAND="dir /b /o:n /ad"
+DIR_NAME_LIST=""
+if [ "${OSTYPE:-}" = "win32" ]; then
+    DIR_NAME_LIST=$(dir /b /o:n /ad "integration/samples/")
 else
-    FIND_COMMAND="find ./integration/samples/* -maxdepth 0 -type d"
+    DIR_NAME_LIST=$(dir --format=vertical --escape "integration/samples/")
 fi
+printf "Processing integration/samples:\n%s" "${DIR_NAME_LIST}"
+PACKAGE_FILE_CANDIDATES="ng-packagr-api.js  ng-package.js  ng-package.json  package.json"
 
-for D in $FIND_COMMAND
-do
-    P_JS=${D}/ng-package.js
-    P_JSON=${D}/ng-package.json
-    P_API=${D}/ng-packagr-api.js
-    P=${D}/package.json
+for DIR_NAME in $DIR_NAME_LIST; do
+    PACKAGE_PATH="integration/samples/${DIR_NAME}"
+    printf "\n\nProcessing integration sample: %s\n" "${PACKAGE_PATH}"
 
-    if [ -f $P_API ]; then
-        echo "Building sample ${P_API}..."
-        node ${P_API}
-    elif [ -f $P_JS ]; then
-        echo "Building sample ${P_JS}..."
-        node dist/cli/main.js -p ${P_JS}
-    elif [ -f $P_JSON ]; then
-        echo "Building sample ${P_JSON}..."
-        node dist/cli/main.js -p ${P_JSON}
-    elif [ -f $P ]; then
-        echo "Building sample ${P}..."
-        if [ $P='failures' ]; then
-            node dist/cli/main.js -p ${P} || true
-        else
-            node dist/cli/main.js -p ${P}
+    PACKAGE_FILE_NAME=""
+    for FILE in $PACKAGE_FILE_CANDIDATES; do
+        if [ -f "${PACKAGE_PATH}/${FILE}" ]; then
+            PACKAGE_FILE_NAME="${FILE}"
+            break;
         fi
+    done
+
+    if [ -n "${PACKAGE_FILE_NAME}" ]; then
+        printf "Found ng-packagr file: %s\n" "${PACKAGE_FILE_NAME}"
+    else
+        printf "No package found in directory, skipping: %s\n" "${PACKAGE_PATH}"
+        continue;
     fi
-    echo "Built."
+
+    # All integration samples starting with "fail" are expected to fail.
+    EXPECTED_TO_FAIL=false
+    case "${DIR_NAME}" in
+        "fail"*)
+            printf "NOTE: This next package build is expected to fail!\n"
+            EXPECTED_TO_FAIL=true
+            ;;
+    esac
+
+    if [ "${PACKAGE_FILE_NAME}" = "ng-packagr-api.js" ]; then
+        node "${PACKAGE_PATH}/${PACKAGE_FILE_NAME}"
+    elif $EXPECTED_TO_FAIL; then
+        if node dist/cli/main.js -p "${PACKAGE_PATH}/${PACKAGE_FILE_NAME}"; then
+          printf "ERROR: Package build was expected to fail!\n"
+          exit 1
+        fi
+    else
+        node dist/cli/main.js -p "${PACKAGE_PATH}/${PACKAGE_FILE_NAME}"
+    fi
+
+    printf "Finished processing: %s!\n" "${PACKAGE_PATH}"
 done
+
+printf "Finished processing all integration samples!\n"


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Makes the shell code compatible with more systems by using POSIX compatible code. Main changes:

* Disabled glob expansion in favor of a simple dir command, this fixed a bug where the find command was actually treated as a glob and not as an actual command.
* Toggling the fail on error flag to avoid using `|| true`, this fixed a bug where builds that were expected to fail could stop failing because of regressions in the build system and the script would not see this as a problem.
* Took the liberty and added a link to ShellCheck, which is a nice utility that's available on most system.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
