### PR TITLE
build: remove @types/uglify-js from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "^9.0.0",
     "@types/stylus": "^0.48.30",
-    "@types/uglify-js": "^3.0.2",
     "chai": "^4.0.1",
     "cross-env": "^7.0.0",
     "husky": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,13 +625,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/uglify-js@^3.0.2":
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.11.1.tgz#97ff30e61a0aa6876c270b5f538737e2d6ab8ceb"
-  integrity sha512-7npvPKV+jINLu1SpSYVWG8KvyJBhBa8tmzMMdDoVc2pWUYHN8KIXlPJhjJ4LT97c4dXJA2SHL/q6ADbDriZN+Q==
-  dependencies:
-    source-map "^0.6.1"
-
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

`uglify-js` has been replaced by `@types/uglify-js in a18d7ad2, this PR removes the types which are no longer used.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
