### PR TITLE
test: cleanup in case of compilation error

### DIFF
--- a/integration/samples/fail-no-such-module/README.md
+++ b/integration/samples/fail-no-such-module/README.md
@@ -1,0 +1,7 @@
+# fail-no-such-module
+
+The build is expected to fail because of a missing imported module, causing the output directory to not exist.
+
+Expected build error:
+
+> TS2307: Cannot find module '@example/fail-no-such-module' or its corresponding type declarations.

--- a/integration/samples/fail-no-such-module/index.ts
+++ b/integration/samples/fail-no-such-module/index.ts
@@ -1,0 +1,4 @@
+// NOTE: The '@example/fail-no-such-module' module doesn't exist.
+import * as exampleModule from '@example/fail-no-such-module';
+
+export const EXAMPLE_CORE_INSTANCE = exampleModule('no such module');

--- a/integration/samples/fail-no-such-module/package.json
+++ b/integration/samples/fail-no-such-module/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fail-no-such-module",
+  "private": true,
+  "ngPackage": {
+    "deleteDestPath": true,
+    "lib": {
+      "entryFile": "index.ts"
+    }
+  }
+}

--- a/integration/samples/fail-no-such-module/specs/fail-no-such-module.ts
+++ b/integration/samples/fail-no-such-module/specs/fail-no-such-module.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+describe(`fail-no-such-module `, () => {
+  describe(`library build error`, () => {
+    it(`should have no build output`, () => {
+      const exists = fs.existsSync(path.resolve(__dirname, '../dist'));
+      expect(exists).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Adds a new `fail-no-such-module` integration sample for checking if the output is cleaned up in case of errors thrown by the Angular compiler. This is a first test for #1858, I will prepare a fix and another test in the future.

NOTE: The existing `fail-missing-deps` integration sample checks if the output is cleaned up in case of errors thrown by `ng-packagr` itself when a dependency doesn't exist in the current workspace.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
