### PR TITLE
refactor: update to use Node 12 APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "css",
     "scss"
   ],
+  "engines": {
+    "node": ">=12.13.0"
+  },
   "author": "David Herges <david@spektrakel.de>",
   "license": "MIT",
   "repository": "https://github.com/ng-packagr/ng-packagr.git",

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -3,10 +3,7 @@ import { WriteStream } from 'tty';
 
 type AnsiColors = typeof ansiColors;
 
-// Typings do not contain the function call (added in Node.js v9.9.0)
-const supportsColor =
-  process.stdout instanceof WriteStream &&
-  ((process.stdout as unknown) as { getColorDepth(): number }).getColorDepth() > 1;
+const supportsColor = process.stdout instanceof WriteStream && process.stdout.getColorDepth() > 1;
 
 // Create a separate instance to prevent unintended global changes to the color configuration
 // Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
@@ -14,3 +11,4 @@ const colors = (ansiColors as AnsiColors & { create: () => AnsiColors }).create(
 colors.enabled = supportsColor;
 
 export { colors };
+``;

--- a/src/lib/utils/fs.ts
+++ b/src/lib/utils/fs.ts
@@ -4,11 +4,11 @@ import * as fs from 'fs';
 import { dirname } from 'path';
 
 export const rimraf = promisify(rm);
-export const readFile = promisify(fs.readFile);
-export const writeFile = promisify(fs.writeFile);
-export const access = promisify(fs.access);
-export const mkdir = promisify(fs.mkdir);
-export const stat = promisify(fs.stat);
+export const readFile = fs.promises.readFile;
+export const writeFile = fs.promises.writeFile;
+export const access = fs.promises.access;
+export const mkdir = fs.promises.mkdir;
+export const stat = fs.promises.stat;
 
 export async function exists(path: fs.PathLike): Promise<boolean> {
   try {


### PR DESCRIPTION
BREAKING CHANGE:
Node.js version 10 will become EOL on 2021-04-30.
Angular CLI 12 will require Node.js 12.13+ or 14.15+. Node.js 12.13 and 14.15 are the first LTS releases for their respective majors.