### PR TITLE
refactor: remove read-pkg-up dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ora": "^5.1.0",
     "postcss": "^8.2.4",
     "postcss-url": "^10.1.1",
-    "read-pkg-up": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^2.37.0",
     "rollup-plugin-sourcemaps": "^0.6.3",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,8 +2,7 @@
 
 import * as program from 'commander';
 import * as path from 'path';
-import * as readPkgUp from 'read-pkg-up';
-import { execute, build, version } from '../public_api';
+import { build, execute, version } from '../public_api';
 
 const DEFAULT_PROJECT_PATH = path.resolve(process.cwd(), 'ng-package.json');
 
@@ -26,11 +25,8 @@ program
     value ? path.resolve(value) : undefined,
   );
 
-const dir = path.dirname(module.filename);
-const pkg = readPkgUp.sync({ cwd: dir }).pkg;
-
 program.on('option:version', () => {
-  version(pkg);
+  version();
   process.exit(0);
 });
 

--- a/src/lib/commands/version.command.ts
+++ b/src/lib/commands/version.command.ts
@@ -8,17 +8,9 @@ import { Command } from './command';
  *
  * @stable
  */
-export const version: Command<any, void> = (pkg: any) => {
-  let TSICKLE_VERSION = '';
-  try {
-    TSICKLE_VERSION = require('tsickle/package.json').version;
-  } catch {}
-
-  const NG_PACKAGR_VERSION = pkg ? pkg.version : 'unknown';
-
-  console.log(`ng-packagr:            ` + NG_PACKAGR_VERSION);
+export const version: Command<any, void> = () => {
+  console.log(`ng-packagr:            ` + require('../../package.json').version);
   console.log(`@angular/compiler:     ` + COMPILER_VERSION.full);
   console.log(`rollup:                ` + ROLLUP_VERSION);
-  console.log(`tsickle:               ` + TSICKLE_VERSION);
   console.log(`typescript:            ` + TS_VERSION);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,14 +3862,6 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
-read-pkg-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-5.0.0.tgz#b6a6741cb144ed3610554f40162aa07a6db621b8"
-  integrity sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==
-  dependencies:
-    find-up "^3.0.0"
-    read-pkg "^5.0.0"
-
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -3897,7 +3889,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read-pkg@^5.0.0, read-pkg@^5.2.0:
+read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
   integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Removed direct dependency on `read-pkg-up@5`, it adds 40 dependencies for users of `ng-packagr`, and this dependency can be replaced by a few lines of code.

NOTE: The project still has an indirect dev-dependency through `standard-version`, which is used for making releases.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

--- 

Closes #1407
