### PR TITLE
perf: use sync-rcp instead of execFileSync to transform async function to sync functions #1872

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rxjs": "^6.5.0",
     "sass": "^1.32.5",
     "stylus": "^0.54.8",
+    "sync-rpc": "^1.3.6",
     "terser": "^5.5.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,6 +2081,11 @@ get-pkg-repo@^1.0.0:
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
 
+get-port@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
+  integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
+
 get-stdin@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
@@ -4504,6 +4509,13 @@ svgo@^1.0.0:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+sync-rpc@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/sync-rpc/-/sync-rpc-1.3.6.tgz#b2e8b2550a12ccbc71df8644810529deb68665a7"
+  integrity sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==
+  dependencies:
+    get-port "^3.1.0"
 
 terser@^5.5.1:
   version "5.5.1"


### PR DESCRIPTION
By using sync-rpc ( which is also used by the [babel-plugin-postcss](https://github.com/unlight/babel-plugin-postcss/blob/master/src/getcss.ts#L14-L15) package ), we increase the performance
over execFileSync calls, which are very expensive.

## I'm submitting a...

```
[x] Performance improvement
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
- [ ] Tests for the changes have been added

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
