### PR TITLE
fix: show error when template file is unreadable

### DIFF
--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -136,6 +136,10 @@ export function cacheCompilerHost(
           cache.content = stylesheetProcessor.process(fileName);
         }
 
+        if (cache.content === undefined) {
+          throw new Error(`Cannot read file ${fileName}.`);
+        };
+
         cache.exists = true;
       }
 


### PR DESCRIPTION
Closes https://github.com/angular/angular-cli/issues/20080
