### PR TITLE
refactor: renaming whitelistedNonPeerDependencies in favor of allowedNonPeerDependencies

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,20 +12,20 @@ While this is a desirable solution on server-side or standalone programs, it's a
 
 A motivation why `peerDependencies` are the preferred solution for libraries can be found on the [Hidden Variables blog](https://blog.domenic.me/peer-dependencies).
 
-## Whitelisting the `dependencies` Section
+## Allowing in the `dependencies` Section
 
 To mitigate the risk of accidentally publishing libraries with `dependencies`, ng-packagr verifies `dependencies` at build time.
-It will fail the build, if a dependency is not whitelisted explicitly.
+It will fail the build, if a dependency is not allowed explicitly.
 It is a safety net to keep the ecosystem of Angular libraries healthy.
 
-Whitelisting can be done using the `whitelistedNonPeerDependencies` option in the ng-packagr configuration. Each entry will be matched as a RegExp.
+Allowing can be done using the `allowedNonPeerDependencies` option in the ng-packagr configuration. Each entry will be matched as a RegExp.
 a
 In `ng-package.json`:
 
 ```json
 {
   "$schema": "./node_modules/ng-packagr/package.schema.json",
-  "whitelistedNonPeerDependencies": ["moment"]
+  "allowedNonPeerDependencies": ["moment"]
 }
 ```
 
@@ -35,7 +35,7 @@ in `package.json`:
 {
   "$schema": "./node_modules/ng-packagr/package.schema.json",
   "ngPackage": {
-    "whitelistedNonPeerDependencies": ["moment"]
+    "allowedNonPeerDependencies": ["moment"]
   }
 }
 ```
@@ -46,7 +46,7 @@ If you'd like to turn off this feature completely, you can do so by providing a 
 {
   "$schema": "./node_modules/ng-packagr/package.schema.json",
   "ngPackage": {
-    "whitelistedNonPeerDependencies": ["."]
+    "allowedNonPeerDependencies": ["."]
   }
 }
 ```

--- a/integration/samples/externals/ng-package.json
+++ b/integration/samples/externals/ng-package.json
@@ -3,5 +3,5 @@
   "lib": {
     "entryFile": "public_api.ts"
   },
-  "allowedNonPeerDependencies": ["."]
+  "whitelistedNonPeerDependencies": ["."]
 }

--- a/integration/samples/externals/ng-package.json
+++ b/integration/samples/externals/ng-package.json
@@ -3,5 +3,5 @@
   "lib": {
     "entryFile": "public_api.ts"
   },
-  "whitelistedNonPeerDependencies": ["."]
+  "allowedNonPeerDependencies": ["."]
 }

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -181,9 +181,15 @@ async function writePackageJson(
 
   // Verify non-peerDependencies as they can easily lead to duplicate installs or version conflicts
   // in the node_modules folder of an application
-  const whitelist = pkg.whitelistedNonPeerDependencies.map(value => new RegExp(value));
+  const allowedList = pkg.allowedNonPeerDependencies.map(value => new RegExp(value));
   try {
-    checkNonPeerDependencies(packageJson, 'dependencies', whitelist, spinner);
+    if(pkg.whitelistedNonPeerDependencies) {
+      spinner.warn(
+        colors.yellow(`'whitelistedNonPeerDependencies' is being deprecated, use 'allowedNonPeerDependencies' instead.`)
+      );
+    }
+    
+    checkNonPeerDependencies(packageJson, 'dependencies', allowedList, spinner);
   } catch (e) {
     await rimraf(entryPoint.destinationPath);
     throw e;
@@ -241,7 +247,7 @@ async function writePackageJson(
 function checkNonPeerDependencies(
   packageJson: Record<string, unknown>,
   property: string,
-  whitelist: RegExp[],
+  allowed: RegExp[],
   spinner: ora.Ora,
 ) {
   if (!packageJson[property]) {
@@ -249,15 +255,15 @@ function checkNonPeerDependencies(
   }
 
   for (const dep of Object.keys(packageJson[property])) {
-    if (whitelist.find(regex => regex.test(dep))) {
-      log.debug(`Dependency ${dep} is whitelisted in '${property}'`);
+    if (allowed.find(regex => regex.test(dep))) {
+      log.debug(`Dependency ${dep} is allowed in '${property}'`);
     } else {
       spinner.warn(
         colors.yellow(
           `Distributing npm packages with '${property}' is not recommended. Please consider adding ${dep} to 'peerDependencies' or remove it from '${property}'.`,
         ),
       );
-      throw new Error(`Dependency ${dep} must be explicitly whitelisted.`);
+      throw new Error(`Dependency ${dep} must be explicitly allowed.`);
     }
   }
 }

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -183,12 +183,6 @@ async function writePackageJson(
   // in the node_modules folder of an application
   const allowedList = pkg.allowedNonPeerDependencies.map(value => new RegExp(value));
   try {
-    if(pkg.whitelistedNonPeerDependencies) {
-      spinner.warn(
-        colors.yellow(`'whitelistedNonPeerDependencies' is being deprecated, use 'allowedNonPeerDependencies' instead.`)
-      );
-    }
-    
     checkNonPeerDependencies(packageJson, 'dependencies', allowedList, spinner);
   } catch (e) {
     await rimraf(entryPoint.destinationPath);
@@ -255,7 +249,7 @@ function checkNonPeerDependencies(
   }
 
   for (const dep of Object.keys(packageJson[property])) {
-    if (allowed.find(regex => regex.test(dep))) {
+    if (allowed.some(regex => regex.test(dep))) {
       log.debug(`Dependency ${dep} is allowed in '${property}'`);
     } else {
       spinner.warn(
@@ -263,7 +257,7 @@ function checkNonPeerDependencies(
           `Distributing npm packages with '${property}' is not recommended. Please consider adding ${dep} to 'peerDependencies' or remove it from '${property}'.`,
         ),
       );
-      throw new Error(`Dependency ${dep} must be explicitly allowed.`);
+      throw new Error(`Dependency ${dep} must be explicitly allowed using the "allowedNonPeerDependencies" option.`);
     }
   }
 }

--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -77,14 +77,22 @@ export class NgPackage {
   public get allowedNonPeerDependencies(): string[] {
     const alwaysInclude = ['tslib'];
 
-    const allowedNonPeerDependencies = this.primary.$get('allowedNonPeerDependencies') as string[];
-    
     // remove in the future, after deprecation phase
     const deprecatedPropList = this.whitelistedNonPeerDependencies;
 
-    return Array.from(
+    if(deprecatedPropList.length) {
+      return Array.from(
+        new Set([
+          ...deprecatedPropList,
+          ...alwaysInclude,
+        ])
+      );
+    }
+
+    const allowedNonPeerDependencies = this.primary.$get('allowedNonPeerDependencies') as string[];
+    
+    Array.from(
       new Set([
-        ...deprecatedPropList,
         ...allowedNonPeerDependencies,
         ...alwaysInclude,
       ])

--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -79,13 +79,13 @@ export class NgPackage {
 
     const allowedNonPeerDependencies = this.primary.$get('allowedNonPeerDependencies') as string[];
     
-    // deprecated prop list
-    const deprecated = this.whitelistedNonPeerDependencies;
+    // remove in the future, after deprecation phase
+    const deprecatedPropList = this.whitelistedNonPeerDependencies;
 
     return Array.from(
       new Set([
-        ...(deprecated ? deprecated : []),
-        ...(allowedNonPeerDependencies ? allowedNonPeerDependencies : []) ,
+        ...deprecatedPropList,
+        ...allowedNonPeerDependencies,
         ...alwaysInclude,
       ])
     );

--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -91,7 +91,7 @@ export class NgPackage {
 
     const allowedNonPeerDependencies = this.primary.$get('allowedNonPeerDependencies') as string[];
     
-    Array.from(
+    return Array.from(
       new Set([
         ...allowedNonPeerDependencies,
         ...alwaysInclude,

--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -75,17 +75,20 @@ export class NgPackage {
   }
 
   public get allowedNonPeerDependencies(): string[] {
-    // XX: default array values from JSON schema not recognized
-    const defValue = ['tslib'];
+    const alwaysInclude = ['tslib'];
 
-    // deprecated name
-    const deprecatedPropList = this.primary.$get('whitelistedNonPeerDependencies') as string[];
+    const allowedNonPeerDependencies = this.primary.$get('allowedNonPeerDependencies') as string[];
+    
+    // deprecated prop list
+    const deprecated = this.whitelistedNonPeerDependencies;
 
-    const allowed = this.primary.$get('allowedNonPeerDependencies') as string[];
-    const value = (deprecatedPropList ? deprecatedPropList : allowed) || defValue;
-
-    // Always append 'tslib' and dedupe
-    return value.concat('tslib').filter((value, index, self) => self.indexOf(value) === index);
+    return Array.from(
+      new Set([
+        ...(deprecated ? deprecated : []),
+        ...(allowedNonPeerDependencies ? allowedNonPeerDependencies : []) ,
+        ...alwaysInclude,
+      ])
+    );
   }
 
   private absolutePathFromPrimary(key: string) {

--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -67,10 +67,22 @@ export class NgPackage {
     return this.primary.$get('assets');
   }
 
+  /**
+   * @deprecated Use allowedNonPeerDependencies instead.
+   */
   public get whitelistedNonPeerDependencies(): string[] {
+    return this.primary.$get('whitelistedNonPeerDependencies') as string[];
+  }
+
+  public get allowedNonPeerDependencies(): string[] {
     // XX: default array values from JSON schema not recognized
     const defValue = ['tslib'];
-    const value = (this.primary.$get('whitelistedNonPeerDependencies') as string[]) || defValue;
+
+    // deprecated name
+    const deprecatedPropList = this.primary.$get('whitelistedNonPeerDependencies') as string[];
+
+    const allowed = this.primary.$get('allowedNonPeerDependencies') as string[];
+    const value = (deprecatedPropList ? deprecatedPropList : allowed) || defValue;
 
     // Always append 'tslib' and dedupe
     return value.concat('tslib').filter((value, index, self) => self.indexOf(value) === index);

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -32,7 +32,8 @@
       "default": ["tslib"]
     },
     "whitelistedNonPeerDependencies": {
-      "description": "A deprecated alias for 'allowedNonPeerDependencies'",
+      "x-deprecated": "Use \"allowedNonPeerDependencies\" instead.",
+      "description": "A list of dependencies that are allowed in the 'dependencies' and 'devDependencies' section of package.json. Values in the list are regular expressions matched against npm package names.",
       "type": "array",
       "items": {
         "type": "string"

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -23,8 +23,16 @@
       "type": "boolean",
       "default": false
     },
-    "whitelistedNonPeerDependencies": {
+    "allowedNonPeerDependencies": {
       "description": "A list of dependencies that are allowed in the 'dependencies' and 'devDependencies' section of package.json. Values in the list are regular expressions matched against npm package names.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["tslib"]
+    },
+    "whitelistedNonPeerDependencies": {
+      "description": "A deprecated alias for 'allowedNonPeerDependencies'",
       "type": "array",
       "items": {
         "type": "string"

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -28,8 +28,7 @@
       "type": "array",
       "items": {
         "type": "string"
-      },
-      "default": ["tslib"]
+      }
     },
     "whitelistedNonPeerDependencies": {
       "x-deprecated": "Use \"allowedNonPeerDependencies\" instead.",

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -28,7 +28,8 @@
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "default": []
     },
     "whitelistedNonPeerDependencies": {
       "x-deprecated": "Use \"allowedNonPeerDependencies\" instead.",
@@ -37,7 +38,7 @@
       "items": {
         "type": "string"
       },
-      "default": ["tslib"]
+      "default": []
     },
     "assets": {
       "type": "array",


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[X] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

https://github.com/ng-packagr/ng-packagr/issues/1884

Moved the functionality of `whitelistedNonPeerDependencies` into `allowedNonPeerDependencies`. 

Updated the JSON schema to reflect that `whitelistedNonPeerDependencies` is a deprecated field, added `allowedNonPeerDependencies` to the schema.  Also updated the documentation where the phrasing "white list" appears.

Added a warning message if `whitelistedNonPeerDependencies` is detected in the ng-package.json that it is being deprecated.


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
