### PR TITLE
feat: allow publishing of Ivy library in partial mode.

### DIFF
--- a/src/lib/ng-package/entry-point/init-tsconfig.transform.ts
+++ b/src/lib/ng-package/entry-point/init-tsconfig.transform.ts
@@ -1,25 +1,13 @@
 import { ParsedConfiguration } from '@angular/compiler-cli';
-import { colors } from '../../utils/color';
 import { Transform, transformFromPromise } from '../../graph/transform';
 import { isEntryPoint, EntryPointNode } from '../nodes';
 import { initializeTsConfig } from '../../ts/tsconfig';
-import { msg } from '../../utils/log';
 
 export const initTsConfigTransformFactory = (defaultTsConfig: ParsedConfiguration): Transform =>
   transformFromPromise(async graph => {
     // Initialize tsconfig for each entry point
     const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
     initializeTsConfig(defaultTsConfig, entryPoints);
-
-    if (defaultTsConfig.options.enableIvy) {
-      const ivyMsg =
-        '******************************************************************************\n' +
-        'It is not recommended to publish Ivy libraries to NPM repositories.\n' +
-        'Read more here: https://v9.angular.io/guide/ivy#maintaining-library-compatibility\n' +
-        '******************************************************************************';
-
-      msg(colors.yellow(ivyMsg));
-    }
 
     return graph;
   });


### PR DESCRIPTION
Ivy libraries are not allowed to be published when compiled in partial mode. To enable this mode, add `compilationMode: "partial"` under the `angularCompilerOptions` section in the library's tsconfig.

Closes #1901
