### PR TITLE
fix: add version stamping during watch builds

### DIFF
--- a/integration/watch/basic.spec.ts
+++ b/integration/watch/basic.spec.ts
@@ -17,6 +17,10 @@ describe('basic', () => {
   });
 
   describe('primary entrypoint', () => {
+    it("should set a `0.0.0-watch+...` as version number", () => {
+      harness.expectPackageManifestToMatch(/"version": "0\.0\.0-watch\+\d+"/);
+    });
+
     it("should perform initial compilation when 'watch' is started", () => {
       harness.expectDtsToMatch('public_api', /title = "hello world"/);
       harness.expectFesm2015ToMatch('basic', /hello world/);

--- a/integration/watch/test-harness.ts
+++ b/integration/watch/test-harness.ts
@@ -75,6 +75,10 @@ export class TestHarness {
     return expect(this.readFileSync(`${fileName}.d.ts`)).to.match(regexp);
   }
 
+  expectPackageManifestToMatch(regexp: RegExp): Chai.Assertion {
+    return expect(this.readFileSync('package.json')).to.match(regexp);
+  }
+
   expectMetadataToContain(fileName: string, path: string, value: any): Chai.Assertion {
     const data = this.readFileSync(`${fileName}.metadata.json`, true);
     return expect(data).to.have.nested.property(path, value);

--- a/src/lib/ng-package/entry-point/write-package.di.ts
+++ b/src/lib/ng-package/entry-point/write-package.di.ts
@@ -2,10 +2,12 @@ import { InjectionToken } from 'injection-js';
 import { Transform } from '../../graph/transform';
 import { TransformProvider, provideTransform } from '../../graph/transform.di';
 import { writePackageTransform } from './write-package.transform';
+import { OPTIONS_TOKEN } from '../options.di';
 
 export const WRITE_PACKAGE_TRANSFORM_TOKEN = new InjectionToken<Transform>(`ng.v5.writePackageTransform`);
 
 export const WRITE_PACKAGE_TRANSFORM: TransformProvider = provideTransform({
   provide: WRITE_PACKAGE_TRANSFORM_TOKEN,
-  useFactory: () => writePackageTransform,
+  useFactory: writePackageTransform,
+  deps: [OPTIONS_TOKEN],
 });

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as ora from 'ora';
-import { Transform, transformFromPromise } from '../../graph/transform';
+import { transformFromPromise } from '../../graph/transform';
 import { colors } from '../../utils/color';
 import { NgEntryPoint } from './entry-point';
 import { NgPackage } from '../package';
@@ -10,117 +10,120 @@ import * as log from '../../utils/log';
 import { globFiles } from '../../utils/glob';
 import { EntryPointNode, isEntryPointInProgress, isPackage, PackageNode, fileUrl } from '../nodes';
 import { Node } from '../../graph/node';
+import { NgPackagrOptions } from '../options.di';
 
-type CompilationMode =  'partial' | 'full' | undefined;
+type CompilationMode = 'partial' | 'full' | undefined;
 
-export const writePackageTransform: Transform = transformFromPromise(async graph => {
-  const spinner = ora({
-    hideCursor: false,
-    discardStdin: false,
-  });
-  const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
-  const ngEntryPoint: NgEntryPoint = entryPoint.data.entryPoint;
-  const ngPackageNode: PackageNode = graph.find(isPackage);
-  const ngPackage = ngPackageNode.data;
-  const { destinationFiles } = entryPoint.data;
-  const ignorePaths: string[] = [
-    '.gitkeep',
-    '**/.DS_Store',
-    '**/Thumbs.db',
-    '**/node_modules/**',
-    `${ngPackage.dest}/**`,
-  ];
+export const writePackageTransform = (options: NgPackagrOptions) =>
+  transformFromPromise(async graph => {
+    const spinner = ora({
+      hideCursor: false,
+      discardStdin: false,
+    });
+    const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
+    const ngEntryPoint: NgEntryPoint = entryPoint.data.entryPoint;
+    const ngPackageNode: PackageNode = graph.find(isPackage);
+    const ngPackage = ngPackageNode.data;
+    const { destinationFiles } = entryPoint.data;
+    const ignorePaths: string[] = [
+      '.gitkeep',
+      '**/.DS_Store',
+      '**/Thumbs.db',
+      '**/node_modules/**',
+      `${ngPackage.dest}/**`,
+    ];
 
-  if (ngPackage.assets.length && !ngEntryPoint.isSecondaryEntryPoint) {
-    const assetFiles: string[] = [];
+    if (ngPackage.assets.length && !ngEntryPoint.isSecondaryEntryPoint) {
+      const assetFiles: string[] = [];
 
-    // COPY ASSET FILES TO DESTINATION
-    spinner.start('Copying assets');
+      // COPY ASSET FILES TO DESTINATION
+      spinner.start('Copying assets');
 
+      try {
+        for (let asset of ngPackage.assets) {
+          asset = path.join(ngPackage.src, asset);
+
+          if (await exists(asset)) {
+            const stats = await stat(asset);
+            if (stats.isFile()) {
+              assetFiles.push(asset);
+              continue;
+            }
+
+            if (stats.isDirectory()) {
+              asset = path.join(asset, '**/*');
+            }
+          }
+
+          const files = await globFiles(asset, {
+            ignore: ignorePaths,
+            cache: ngPackageNode.cache.globCache,
+            dot: true,
+            nodir: true,
+          });
+
+          if (files.length) {
+            assetFiles.push(...files);
+          }
+        }
+
+        for (const file of assetFiles) {
+          const relativePath = path.relative(ngPackage.src, file);
+          const destination = path.resolve(ngPackage.dest, relativePath);
+          const nodeUri = fileUrl(ensureUnixPath(file));
+          let node = graph.get(nodeUri);
+          if (!node) {
+            node = new Node(nodeUri);
+            graph.put(node);
+          }
+
+          entryPoint.dependsOn(node);
+          await copyFile(file, destination);
+        }
+      } catch (error) {
+        spinner.fail();
+        throw error;
+      }
+      spinner.succeed();
+    }
+
+    // 6. WRITE PACKAGE.JSON
     try {
-      for (let asset of ngPackage.assets) {
-        asset = path.join(ngPackage.src, asset);
+      spinner.start('Writing package metadata');
+      const relativeUnixFromDestPath = (filePath: string) =>
+        ensureUnixPath(path.relative(ngEntryPoint.destinationPath, filePath));
 
-        if (await exists(asset)) {
-          const stats = await stat(asset);
-          if (stats.isFile()) {
-            assetFiles.push(asset);
-            continue;
-          }
+      const { enableIvy, compilationMode } = entryPoint.data.tsConfig.options;
 
-          if (stats.isDirectory()) {
-            asset = path.join(asset, '**/*');
-          }
-        }
-
-        const files = await globFiles(asset, {
-          ignore: ignorePaths,
-          cache: ngPackageNode.cache.globCache,
-          dot: true,
-          nodir: true,
-        });
-
-        if (files.length) {
-          assetFiles.push(...files);
-        }
-      }
-
-      for (const file of assetFiles) {
-        const relativePath = path.relative(ngPackage.src, file);
-        const destination = path.resolve(ngPackage.dest, relativePath);
-        const nodeUri = fileUrl(ensureUnixPath(file));
-        let node = graph.get(nodeUri);
-        if (!node) {
-          node = new Node(nodeUri);
-          graph.put(node);
-        }
-
-        entryPoint.dependsOn(node);
-        await copyFile(file, destination);
-      }
+      await writePackageJson(
+        ngEntryPoint,
+        ngPackage,
+        {
+          main: relativeUnixFromDestPath(destinationFiles.umd),
+          module: relativeUnixFromDestPath(destinationFiles.fesm2015),
+          es2015: relativeUnixFromDestPath(destinationFiles.fesm2015),
+          esm2015: relativeUnixFromDestPath(destinationFiles.esm2015),
+          fesm2015: relativeUnixFromDestPath(destinationFiles.fesm2015),
+          typings: relativeUnixFromDestPath(destinationFiles.declarations),
+          // Ivy doesn't generate metadata files
+          metadata: enableIvy ? undefined : relativeUnixFromDestPath(destinationFiles.metadata),
+          // webpack v4+ specific flag to enable advanced optimizations and code splitting
+          sideEffects: ngEntryPoint.sideEffects,
+        },
+        !!enableIvy,
+        !!options.watch,
+        compilationMode as CompilationMode,
+        spinner,
+      );
     } catch (error) {
       spinner.fail();
       throw error;
     }
     spinner.succeed();
-  }
+    spinner.succeed(`Built ${ngEntryPoint.moduleId}`);
 
-  // 6. WRITE PACKAGE.JSON
-  try {
-    spinner.start('Writing package metadata');
-    const relativeUnixFromDestPath = (filePath: string) =>
-      ensureUnixPath(path.relative(ngEntryPoint.destinationPath, filePath));
-
-    const { enableIvy, compilationMode } = entryPoint.data.tsConfig.options;
-
-    await writePackageJson(
-      ngEntryPoint,
-      ngPackage,
-      {
-        main: relativeUnixFromDestPath(destinationFiles.umd),
-        module: relativeUnixFromDestPath(destinationFiles.fesm2015),
-        es2015: relativeUnixFromDestPath(destinationFiles.fesm2015),
-        esm2015: relativeUnixFromDestPath(destinationFiles.esm2015),
-        fesm2015: relativeUnixFromDestPath(destinationFiles.fesm2015),
-        typings: relativeUnixFromDestPath(destinationFiles.declarations),
-        // Ivy doesn't generate metadata files
-        metadata: enableIvy ? undefined : relativeUnixFromDestPath(destinationFiles.metadata),
-        // webpack v4+ specific flag to enable advanced optimizations and code splitting
-        sideEffects: ngEntryPoint.sideEffects,
-      },
-      !!enableIvy,
-      compilationMode as CompilationMode,
-      spinner,
-    );
-  } catch (error) {
-    spinner.fail();
-    throw error;
-  }
-  spinner.succeed();
-  spinner.succeed(`Built ${ngEntryPoint.moduleId}`);
-
-  return graph;
-});
+    return graph;
+  });
 
 /**
  * Creates and writes a `package.json` file of the entry point used by the `node_module`
@@ -142,6 +145,7 @@ async function writePackageJson(
   pkg: NgPackage,
   additionalProperties: { [key: string]: string | boolean | string[] },
   isIvy: boolean,
+  isWatchMode: boolean,
   compilationMode: CompilationMode,
   spinner: ora.Ora,
 ): Promise<void> {
@@ -155,6 +159,12 @@ async function writePackageJson(
   // it will get what installed and not the minimum version nor if it is a `~` or `^`
   // this is only required for primary
   if (!entryPoint.isSecondaryEntryPoint) {
+    if (isWatchMode) {
+      // Needed because of Webpack's 5 `cachemanagedpaths`
+      // https://github.com/angular/angular-cli/issues/20962
+      packageJson.version = `0.0.0-watch+${Date.now()}`;
+    }
+
     if (!packageJson.peerDependencies?.tslib && !packageJson.dependencies?.tslib) {
       const {
         peerDependencies: angularPeerDependencies = {},


### PR DESCRIPTION
During watch builds we add a stamped version in the `package.json`, so that it can be used to invalidate Webpack's build cache.

Closes https://github.com/angular/angular-cli/issues/20962
