### PR TITLE
fix avoid non-actionable template type-checker syntax diagnostics

### DIFF
--- a/src/lib/ivy/compile-source-files.ts
+++ b/src/lib/ivy/compile-source-files.ts
@@ -94,21 +94,24 @@ export async function compileSourceFiles(
     }
   }
 
-  // Collect non-semantic diagnostics
+  // Collect program level diagnostics
   const allDiagnostics: ts.Diagnostic[] = [
     ...angularCompiler.getOptionDiagnostics(),
     ...builder.getOptionsDiagnostics(),
     ...builder.getGlobalDiagnostics(),
-    ...builder.getSyntacticDiagnostics(),
   ];
 
   // Required to support asynchronous resource loading
   // Must be done before creating transformers or getting template diagnostics
   await angularCompiler.analyzeAsync();
 
+  // Collect source file specific diagnostics
   for (const sourceFile of builder.getSourceFiles()) {
     if (!ignoreForDiagnostics.has(sourceFile)) {
-      allDiagnostics.push(...builder.getSemanticDiagnostics(sourceFile));
+      allDiagnostics.push(
+        ...builder.getSyntacticDiagnostics(sourceFile),
+        ...builder.getSemanticDiagnostics(sourceFile),
+      );
     }
 
     if (sourceFile.isDeclarationFile) {


### PR DESCRIPTION
The AOT compiler's internal template type-checking files are not intended to be directly analyzed for diagnostics by the emitting program and are instead analyzed during the template type-checking phase. Previously, only semantic diagnostics were ignored. Now both syntactic and semantic diagnostics are ignored. This change prevents non-actionable diagnostics from being shown during a build.

Addresses: angular/angular#42667

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
