### PR TITLE
feat: add watch options with ignore

### DIFF
--- a/src/lib/file-system/file-watcher.ts
+++ b/src/lib/file-system/file-watcher.ts
@@ -20,7 +20,7 @@ export function createFileWatch(
 
   const watch = chokidar.watch(projectPath, {
     ignoreInitial: true,
-    ignored: [...ignoredPaths, /((^[\/\\])\..)|(\.js$)|(\.map$)|(\.metadata\.json|node_modules)/],
+    ignored: [...ignoredPaths, /((^[\/\\])\..)|(\.js$)|(\.map$)|(\.metadata\.json)/],
     persistent: true,
   });
 

--- a/src/lib/ng-package/options.di.ts
+++ b/src/lib/ng-package/options.di.ts
@@ -4,6 +4,10 @@ export const OPTIONS_TOKEN = new InjectionToken<NgPackagrOptions>(`ng.v5.options
 export interface NgPackagrOptions {
   /** Whether or not ng-packagr will watch for file changes and perform an incremental build. */
   watch?: boolean;
+  watchOptions?: {
+    /** ng-packagr will ignore watching these file changes */
+    ignored?: string[];
+  }
 }
 
 export const provideOptions = (options: NgPackagrOptions = {}): ValueProvider => ({

--- a/src/lib/ng-package/options.di.ts
+++ b/src/lib/ng-package/options.di.ts
@@ -6,7 +6,7 @@ export interface NgPackagrOptions {
   watch?: boolean;
   watchOptions?: {
     /** ng-packagr will ignore watching these file changes */
-    ignored?: string[];
+    ignored?: string | string[];
   }
 }
 

--- a/src/lib/ng-package/options.di.ts
+++ b/src/lib/ng-package/options.di.ts
@@ -1,13 +1,16 @@
 import { InjectionToken, ValueProvider, Provider } from 'injection-js';
 
 export const OPTIONS_TOKEN = new InjectionToken<NgPackagrOptions>(`ng.v5.options`);
+
+export interface NgPackagrWatchOptions {
+  /** ng-packagr will ignore watching these file changes */
+  ignored?: RegExp | string | string[];
+}
+
 export interface NgPackagrOptions {
   /** Whether or not ng-packagr will watch for file changes and perform an incremental build. */
   watch?: boolean;
-  watchOptions?: {
-    /** ng-packagr will ignore watching these file changes */
-    ignored?: string | string[];
-  }
+  watchOptions?: NgPackagrWatchOptions
 }
 
 export const provideOptions = (options: NgPackagrOptions = {}): ValueProvider => ({

--- a/src/lib/ng-package/package.transform.ts
+++ b/src/lib/ng-package/package.transform.ts
@@ -140,7 +140,7 @@ const watchTransformFactory = (
   return source$.pipe(
     switchMap(graph => {
       const { data, cache } = graph.find(isPackage);
-      const ignoredPaths = [data.dest];
+      const ignoredPaths: (RegExp | string)[] = [data.dest];
       const watchOptionsIgnored = options?.watchOptions?.ignored;
       if (watchOptionsIgnored) {
         ignoredPaths.push(...Array.isArray(watchOptionsIgnored) ? watchOptionsIgnored : [watchOptionsIgnored]);

--- a/src/lib/ng-package/package.transform.ts
+++ b/src/lib/ng-package/package.transform.ts
@@ -141,8 +141,9 @@ const watchTransformFactory = (
     switchMap(graph => {
       const { data, cache } = graph.find(isPackage);
       const ignoredPaths = [data.dest];
-      if (options?.watchOptions?.ignored) {
-        ignoredPaths.push(...options?.watchOptions?.ignored);
+      const watchOptionsIgnored = options?.watchOptions?.ignored;
+      if (watchOptionsIgnored) {
+        ignoredPaths.push(...Array.isArray(watchOptionsIgnored) ? watchOptionsIgnored : [watchOptionsIgnored]);
       }
       return createFileWatch(data.src, ignoredPaths).pipe(
         tap(fileChange => {

--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -43,7 +43,7 @@ export class NgPackage {
      * An array of secondary entry points.
      */
     public readonly secondaries: NgEntryPoint[] = [],
-  ) {}
+  ) { }
 
   /** Absolute path of the package's source folder, derived from the user's (primary) package location. */
   public get src(): string {
@@ -80,7 +80,7 @@ export class NgPackage {
     // remove in the future, after deprecation phase
     const deprecatedPropList = this.whitelistedNonPeerDependencies;
 
-    if(deprecatedPropList?.length) {
+    if (deprecatedPropList?.length) {
       return Array.from(
         new Set([
           ...deprecatedPropList,
@@ -90,7 +90,7 @@ export class NgPackage {
     }
 
     const allowedNonPeerDependencies = this.primary.$get('allowedNonPeerDependencies') as string[];
-    
+
     return Array.from(
       new Set([
         ...allowedNonPeerDependencies,

--- a/src/lib/packagr.ts
+++ b/src/lib/packagr.ts
@@ -8,7 +8,7 @@ import { provideTsConfig } from './ng-package/entry-point/init-tsconfig.di';
 import { ENTRY_POINT_PROVIDERS } from './ng-package/entry-point/entry-point.di';
 import { PACKAGE_TRANSFORM, PACKAGE_PROVIDERS } from './ng-package/package.di';
 import { provideProject } from './project.di';
-import { provideOptions, NgPackagrOptions } from './ng-package/options.di';
+import { provideOptions, NgPackagrOptions, NgPackagrWatchOptions } from './ng-package/options.di';
 
 /**
  * The original ng-packagr implemented on top of a rxjs-ified and di-jectable transformation pipeline.
@@ -20,7 +20,7 @@ import { provideOptions, NgPackagrOptions } from './ng-package/options.di';
 export class NgPackagr {
   private buildTransform: InjectionToken<Transform> = PACKAGE_TRANSFORM.provide;
 
-  constructor(private providers: Provider[]) {}
+  constructor(private providers: Provider[]) { }
 
   /**
    * Adds options to ng-packagr
@@ -97,8 +97,8 @@ export class NgPackagr {
    *
    * @return An observable result of the transformation pipeline.
    */
-  public watch(): Observable<void> {
-    this.providers.push(provideOptions({ watch: true }));
+  public watch(watchOptions?: NgPackagrWatchOptions): Observable<void> {
+    this.providers.push(provideOptions({ watch: true, watchOptions }));
 
     return this.buildAsObservable();
   }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Handles https://github.com/ng-packagr/ng-packagr/issues/1723

Can ignore any file or directories specified inside `ignore` property inside `watchOptions` solves the issue of watching linked libraries.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

Users that want to ignore `node_modules` need to add;
```
watchOptions: {
  ignored: /node_modules/
}
```
