### PR TITLE
fix: set browserslist defaults

### DIFF
--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -42,6 +42,20 @@ export class StylesheetProcessor {
     private readonly styleIncludePaths?: string[],
   ) {
     log.debug(`determine browserslist for ${this.basePath}`);
+    // By default, browserslist defaults are too inclusive
+    // https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522
+
+    // We change the default query to browsers that Angular support.
+    // https://angular.io/guide/browser-support
+    (browserslist.defaults as string[]) = [
+      'last 1 Chrome version',
+      'last 1 Firefox version',
+      'last 2 Edge major versions',
+      'last 2 Safari major versions',
+      'last 2 iOS major versions',
+      'Firefox ESR',
+    ];
+
     this.browserslistData = browserslist(undefined, { path: this.basePath });
     this.targets = transformSupportedBrowsersToTargets(this.browserslistData);
     this.postCssProcessor = this.createPostCssPlugins();


### PR DESCRIPTION
By default, browserslist defaults are too inclusive: https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522

We change the default query to browsers that Angular support: https://angular.io/guide/browser-support
