### PR TITLE
docs: remove section on UMD module names

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -50,26 +50,3 @@ If you'd like to turn off this feature completely, you can do so by providing a 
   }
 }
 ```
-
-## Resolving UMD Module Identifiers
-
-By default, ng-packagr will treat dependencies as external dependencies.
-This means that dependencies are not included in the distributable bundles of the library and thus the application build (and the browser at runtime) needs to resolve dependencies.
-In UMD, the module identifiers such as `@angular/core` are mapped to a UMD module identifier, e.g. a shared global-scoped variable `window.ng.core` in the browser runtime.
-
-When writing the [UMD bundle](https://github.com/umdjs/umd), ng-packagr does its best to provide common default values for the UMD module identifiers.
-Also, `rollup` will do its best to guess the module ID of an external dependency.
-Even then, you should make sure that the UMD module identifiers of the external dependencies are correct.
-In case ng-packagr doesn't provide a default and rollup is unable to guess the correct identifier, you should explicitly provide the module identifier by using `umdModuleIds` in the library's package file section like so:
-
-```json
-{
-  "$schema": "../../../src/ng-package.schema.json",
-  "lib": {
-    "umdModuleIds": {
-      "lodash": "_",
-      "date-fns": "DateFns"
-    }
-  }
-}
-```


### PR DESCRIPTION
The UMD bundles have been removed in APF13 so this commit the UMD module name configuration from the documentation.
