### PR TITLE
fix: force less version 3.5 math behaviour

### DIFF
--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -158,6 +158,7 @@ export class StylesheetProcessor {
           await import('less')
         ).default.render(css, {
           filename: filePath,
+          math: 'always',
           javascriptEnabled: true,
           paths: this.styleIncludePaths,
         });


### PR DESCRIPTION
In version 4, LESS did a breaking change that set parens-division as the default math setting. With this change we change the behavior to mimic version 3.5.

See: https://github.com/less/less.js/releases/tag/v4.0.0

Note: In ng-packagr, the math setting will be the default provided by the LESS compiler in v4.0.0

Closes #2113
