### PR TITLE
fix: force less version 3.5 math behaviour

### DIFF
--- a/src/lib/ivy/styles/stylesheet-processor.ts
+++ b/src/lib/ivy/styles/stylesheet-processor.ts
@@ -162,6 +162,7 @@ export class StylesheetProcessor {
           filename: filePath,
           javascriptEnabled: true,
           paths: this.styleIncludePaths,
+          math: 'always',
         });
 
         return content;

--- a/src/lib/styles/stylesheet-processor-worker.ts
+++ b/src/lib/styles/stylesheet-processor-worker.ts
@@ -122,6 +122,7 @@ async function renderCss(
         filename: filePath,
         javascriptEnabled: true,
         paths: styleIncludePaths,
+        math: 'always',
       });
 
       return content;


### PR DESCRIPTION
In version 4, LESS did a breaking change that set parens-division as the default math setting. With this change we change the behavior to mimic version 3.5.

See: https://github.com/less/less.js/releases/tag/v4.0.0

Note: In ng-packagr, the math setting will be the default provided by the LESS compiler in v4.0.0

Closes #2113

(cherry picked from commit a491faf0a37ea884f0714396b6e38a950d6a4563)
