### PR TITLE
perf: store fesm generation state on disk

### DIFF
--- a/integration/watch/test-harness.ts
+++ b/integration/watch/test-harness.ts
@@ -19,9 +19,11 @@ export class TestHarness {
   private ngPackagr$$: Subscription;
   private loggerStubs: Record<string, jasmine.Spy> = {};
 
-  constructor(private testName: string) {}
+  constructor(private testName: string) {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+  }
 
-  initialize(): Promise<void> {
+  async initialize(): Promise<void> {
     // the below is done in order to avoid poluting the test reporter with build logs
     for (const key in log) {
       if (log.hasOwnProperty(key)) {
@@ -30,8 +32,8 @@ export class TestHarness {
     }
 
     this.emptyTestDirectory();
-    fs.copySync(this.testSrc, this.testTempPath);
-
+    await fs.copy(this.testSrc, this.testTempPath);
+    await new Promise(resolve => setTimeout(resolve, 1000));
     return this.setUpNgPackagr();
   }
 
@@ -48,7 +50,7 @@ export class TestHarness {
 
   reset(): Promise<void> {
     this.completeHandler = () => undefined;
-    return new Promise(resolve => setTimeout(resolve, 500));
+    return new Promise(resolve => setTimeout(resolve, 1000));
   }
 
   readFileSync(filePath: string, isJson = false): string | object {

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -25,9 +25,9 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
         moduleName: ngEntryPoint.moduleId,
         dest: fesm2020,
         cache: cache.rollupFESM2020Cache,
+        cacheDirectory: options.cacheEnabled && options.cacheDirectory,
       });
       spinner.succeed();
-
       if (options.watch) {
         cache.rollupFESM2020Cache = rollupFESMCache;
       }
@@ -43,8 +43,9 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
         entry: esm2020,
         moduleName: ngEntryPoint.moduleId,
         dest: fesm2015,
-        transform: (code, id) => downlevelCodeWithTsc(code, id, options.cacheEnabled && options.cacheDirectory),
+        transform: downlevelCodeWithTsc,
         cache: cache.rollupFESM2015Cache,
+        cacheDirectory: options.cacheEnabled && options.cacheDirectory,
       });
       spinner.succeed();
 


### PR DESCRIPTION
This helps to improve FESM generations of previously run builds by restoring the state of the previous build from disk, which warms up Rollup state.
