### PR TITLE
perf: only re-generate FESMs when ESM has changed

### DIFF
--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -1,9 +1,25 @@
 import ora from 'ora';
+import { dirname } from 'path';
+import { SourceMap } from 'rollup';
 import { downlevelCodeWithTsc } from '../../flatten/downlevel-plugin';
 import { rollupBundleFile } from '../../flatten/rollup';
 import { transformFromPromise } from '../../graph/transform';
+import { generateKey, readCacheEntry, saveCacheEntry } from '../../utils/cache';
+import { mkdir, writeFile } from '../../utils/fs';
 import { EntryPointNode, isEntryPointInProgress } from '../nodes';
 import { NgPackagrOptions } from '../options.di';
+
+interface BundlesCache {
+  hash: string;
+  fesm2020: {
+    code: string;
+    map: SourceMap;
+  };
+  fesm2015: {
+    code: string;
+    map: SourceMap;
+  };
+}
 
 export const writeBundlesTransform = (options: NgPackagrOptions) =>
   transformFromPromise(async graph => {
@@ -17,18 +33,65 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
       discardStdin: false,
     });
 
+    const key = await generateKey(ngEntryPoint.moduleId, esm2020, 'fesm-bundles', tsConfig.options.compilationMode);
+    const hash = await generateKey(...[...cache.outputCache.values()].map(({ version }) => version));
+    const cacheDirectory = options.cacheEnabled && options.cacheDirectory;
+    if (cacheDirectory) {
+      const cacheResult: BundlesCache = await readCacheEntry(options.cacheDirectory, key);
+
+      if (cacheResult?.hash === hash) {
+        try {
+          spinner.start('Writing FESM bundles');
+          await Promise.all([
+            mkdir(dirname(fesm2020), { recursive: true }),
+            mkdir(dirname(fesm2015), { recursive: true }),
+          ]);
+
+          await Promise.all([
+            writeFile(fesm2020, cacheResult.fesm2020.code),
+            writeFile(`${fesm2020}.map`, JSON.stringify(cacheResult.fesm2020.map)),
+            writeFile(fesm2015, cacheResult.fesm2015.code),
+            writeFile(`${fesm2015}.map`, JSON.stringify(cacheResult.fesm2015.map)),
+          ]);
+
+          spinner.succeed('Writing FESM bundles');
+        } catch (error) {
+          spinner.fail();
+          throw error;
+        }
+
+        return;
+      }
+    }
+
+    const fesmCache: Partial<BundlesCache> = {
+      hash,
+    };
+
     try {
       spinner.start('Generating FESM2020');
-      const rollupFESMCache = await rollupBundleFile({
+      const {
+        cache: rollupFESMCache,
+        code,
+        map,
+      } = await rollupBundleFile({
         sourceRoot: tsConfig.options.sourceRoot,
         entry: esm2020,
         moduleName: ngEntryPoint.moduleId,
         dest: fesm2020,
         cache: cache.rollupFESM2020Cache,
-        cacheDirectory: options.cacheEnabled && options.cacheDirectory,
-        fileCache: cache.sourcesFileCache,
+        cacheDirectory,
+        fileCache: cache.outputCache,
+        cacheKey: await generateKey(esm2020, ngEntryPoint.moduleId, fesm2020, tsConfig.options.compilationMode),
       });
+
+      fesmCache.fesm2020 = {
+        code,
+        map,
+      };
+
       spinner.succeed();
+
       if (options.watch) {
         cache.rollupFESM2020Cache = rollupFESMCache;
       }
@@ -39,16 +102,27 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
 
     try {
       spinner.start('Generating FESM2015');
-      const rollupFESMCache = await rollupBundleFile({
+      const {
+        cache: rollupFESMCache,
+        code,
+        map,
+      } = await rollupBundleFile({
         sourceRoot: tsConfig.options.sourceRoot,
         entry: esm2020,
         moduleName: ngEntryPoint.moduleId,
         dest: fesm2015,
         transform: downlevelCodeWithTsc,
         cache: cache.rollupFESM2015Cache,
-        cacheDirectory: options.cacheEnabled && options.cacheDirectory,
-        fileCache: cache.sourcesFileCache,
+        cacheDirectory,
+        fileCache: cache.outputCache,
+        cacheKey: await generateKey(esm2020, ngEntryPoint.moduleId, fesm2015, tsConfig.options.compilationMode),
       });
+
+      fesmCache.fesm2015 = {
+        code,
+        map,
+      };
+
       spinner.succeed();
 
       if (options.watch) {
@@ -57,5 +131,9 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
     } catch (error) {
       spinner.fail();
       throw error;
+    }
+
+    if (cacheDirectory) {
+      await saveCacheEntry(cacheDirectory, key, JSON.stringify(fesmCache));
     }
   });

--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -59,6 +59,8 @@ export function ngUrl(path: string): string {
   return `${URL_PROTOCOL_NG}${path}`;
 }
 
+export type OutputFileCache = Map<string, { version: string; content: string }>;
+
 export class EntryPointNode extends Node {
   readonly type = TYPE_NG_ENTRY_POINT;
 
@@ -75,10 +77,12 @@ export class EntryPointNode extends Node {
       ngccProcessingCache,
       analysesSourcesFileCache: new FileCache(),
       moduleResolutionCache,
+      outputCache: new Map(),
     };
   }
 
   cache: {
+    outputCache: OutputFileCache;
     oldPrograms?: Record<ts.ScriptTarget | 'analysis', Program | ts.Program>;
     sourcesFileCache: FileCache;
     ngccProcessingCache: NgccProcessingCache;

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -61,7 +61,7 @@ export class StylesheetProcessor {
 
     if (!content.includes('@import') && !content.includes('@use') && this.cacheDirectory) {
       // No transitive deps, we can cache more aggressively.
-      key = generateKey(content, ...this.browserslistData);
+      key = await generateKey(content, ...this.browserslistData);
       const result = await readCacheEntry(this.cacheDirectory, key);
       if (result) {
         result.warnings.forEach(msg => log.warn(msg));
@@ -76,7 +76,7 @@ export class StylesheetProcessor {
     // We cannot cache CSS re-rendering phase, because a transitive dependency via (@import) can case different CSS output.
     // Example a change in a mixin or SCSS variable.
     if (!key) {
-      key = generateKey(renderedCss, ...this.browserslistData);
+      key = await generateKey(renderedCss, ...this.browserslistData);
     }
 
     if (this.cacheDirectory) {

--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -77,7 +77,12 @@ export function cacheCompilerHost(
         });
       } else {
         fileName = fileName.replace(/\.js(\.map)?$/, '.mjs$1');
-        sourcesFileCache.getOrCreate(fileName).content = data;
+        const outputCache = entryPoint.cache.outputCache;
+
+        outputCache.set(fileName, {
+          content: data,
+          version: createHash('sha256').update(data).digest('hex'),
+        });
       }
 
       compilerHost.writeFile.call(this, fileName, data, writeByteOrderMark, onError, sourceFiles);

--- a/src/lib/utils/cache.ts
+++ b/src/lib/utils/cache.ts
@@ -1,6 +1,7 @@
 import * as cacache from 'cacache';
 import { createHash } from 'crypto';
 import { readFile } from '../utils/fs';
+import { ngCompilerCli } from './ng-compiler-cli';
 
 let ngPackagrVersion: string | undefined;
 try {
@@ -10,8 +11,18 @@ try {
   ngPackagrVersion = require('../../../package.json').version;
 }
 
-export function generateKey(...valuesToConsider: string[]): string {
-  return createHash('sha1').update(ngPackagrVersion).update(valuesToConsider.join(':')).digest('hex');
+let compilerCliVersion: string | undefined;
+
+export async function generateKey(...valuesToConsider: string[]): Promise<string> {
+  if (compilerCliVersion === undefined) {
+    compilerCliVersion = (await ngCompilerCli()).VERSION.full;
+  }
+
+  return createHash('sha1')
+    .update(ngPackagrVersion)
+    .update(compilerCliVersion)
+    .update(valuesToConsider.join(':'))
+    .digest('hex');
 }
 
 export async function readCacheEntry(cachePath: string, key: string): Promise<any | undefined> {


### PR DESCRIPTION
With this change we only generate the FESM files when the contents of the ESM bundle changes.
