### PR TITLE
fix: RGBA converted to hex notation in component styles breaks IE11

### DIFF
--- a/src/lib/styles/stylesheet-processor-worker.ts
+++ b/src/lib/styles/stylesheet-processor-worker.ts
@@ -19,6 +19,7 @@ async function processCss({
   styleIncludePaths,
   basePath,
   cachePath,
+  targets,
   alwaysUseWasm,
 }: WorkerOptions): Promise<WorkerResult> {
   const esbuild = new EsbuildExecutor(alwaysUseWasm);
@@ -55,6 +56,7 @@ async function processCss({
   const { code, warnings: esBuildWarnings } = await esbuild.transform(result.css, {
     loader: 'css',
     minify: true,
+    target: targets,
     sourcefile: filePath,
   });
 

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -14,6 +14,7 @@ export enum CssUrl {
 export interface WorkerOptions {
   filePath: string;
   basePath: string;
+  targets: string[];
   browserslistData: string[];
   cssUrl?: CssUrl;
   styleIncludePaths?: string[];
@@ -31,6 +32,7 @@ export class StylesheetProcessor {
   private browserslistData: string[] | undefined;
   private worker: Worker | undefined;
   private readonly cachePath: string;
+  private targets: string[];
   private alwaysUseWasm = !EsbuildExecutor.hasNativeSupport();
 
   constructor(
@@ -48,7 +50,22 @@ export class StylesheetProcessor {
 
     if (!this.browserslistData) {
       log.debug(`determine browserslist for ${this.basePath}`);
+      // By default, browserslist defaults are too inclusive
+      // https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522
+
+      // We change the default query to browsers that Angular support.
+      // https://angular.io/guide/browser-support
+      (browserslist.defaults as string[]) = [
+        'last 1 Chrome version',
+        'last 1 Firefox version',
+        'last 2 Edge major versions',
+        'last 2 Safari major versions',
+        'last 2 iOS major versions',
+        'Firefox ESR',
+      ];
+
       this.browserslistData = browserslist(undefined, { path: this.basePath });
+      this.targets = transformSupportedBrowsersToTargets(this.browserslistData);
     }
 
     const workerOptions: WorkerOptions = {
@@ -58,6 +75,7 @@ export class StylesheetProcessor {
       styleIncludePaths: this.styleIncludePaths,
       browserslistData: this.browserslistData,
       cachePath: this.cachePath,
+      targets: this.targets,
       alwaysUseWasm: this.alwaysUseWasm,
     };
 
@@ -83,4 +101,37 @@ export class StylesheetProcessor {
       this.worker.unref();
     }
   }
+}
+
+function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): string[] {
+  const transformed: string[] = [];
+
+  // https://esbuild.github.io/api/#target
+  const esBuildSupportedBrowsers = new Set(['safari', 'firefox', 'edge', 'chrome', 'ios']);
+
+  for (const browser of supportedBrowsers) {
+    let [browserName, version] = browser.split(' ');
+
+    // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
+    if (browserName === 'ios_saf') {
+      browserName = 'ios';
+      // browserslist also uses ranges for iOS Safari versions but only the lowest is required
+      // to perform minimum supported feature checks. esbuild also expects a single version.
+      [version] = version.split('-');
+    }
+
+    if (browserName === 'ie') {
+      transformed.push('edge12');
+    } else if (esBuildSupportedBrowsers.has(browserName)) {
+      if (browserName === 'safari' && version === 'TP') {
+        // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
+        // a Technology Preview (TP) of Safari is assumed to support all currently known features.
+        version = '999';
+      }
+
+      transformed.push(browserName + version);
+    }
+  }
+
+  return transformed.length ? transformed : undefined;
 }


### PR DESCRIPTION
ESBuild which is used to optimize CSS in components, doesn't support IE. With this change we workaround this limitation by adding Edge 13 when the user needs IE 11 support.

Closes https://github.com/angular/angular-cli/issues/22012
