### PR TITLE
fix:handle FORCE_COLOR when stdout is not instance of 'WriteStream'

### DIFF
--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -3,11 +3,37 @@ import { WriteStream } from 'tty';
 
 type AnsiColors = typeof ansiColors;
 
-const supportsColor = process.stdout instanceof WriteStream && process.stdout.getColorDepth() > 1;
+function supportColor(): boolean {
+  if (process.env.FORCE_COLOR !== undefined) {
+    // 2 colors: FORCE_COLOR = 0 (Disables colors), depth 1
+    // 16 colors: FORCE_COLOR = 1, depth 4
+    // 256 colors: FORCE_COLOR = 2, depth 8
+    // 16,777,216 colors: FORCE_COLOR = 3, depth 16
+    // See: https://nodejs.org/dist/latest-v12.x/docs/api/tty.html#tty_writestream_getcolordepth_env
+    // and https://github.com/nodejs/node/blob/b9f36062d7b5c5039498e98d2f2c180dca2a7065/lib/internal/tty.js#L106;
+    switch (process.env.FORCE_COLOR) {
+      case '':
+      case 'true':
+      case '1':
+      case '2':
+      case '3':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  if (process.stdout instanceof WriteStream) {
+    return process.stdout.getColorDepth() > 1;
+  }
+
+  return false;
+}
+
 
 // Create a separate instance to prevent unintended global changes to the color configuration
 // Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
 const colors = (ansiColors as AnsiColors & { create: () => AnsiColors }).create();
-colors.enabled = supportsColor;
+colors.enabled = supportColor();
 
 export { colors };


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

In some cases, custom implementation of stdout, don't extend `WriteStream` which causes colors not to be included in the output.

This pull request is the same that @alan-agius4  made in @angular/cli [here](https://github.com/angular/angular-cli/commit/d3fa202e9a26926f0660b1e1f156012ea41b1711)  
@alan-agius4  has all the merits, thank you


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
