### PR TITLE
fix: correctly append `sourceMappingUrl` when saving FESMs into cache

### DIFF
--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -85,7 +85,7 @@ export async function rollupBundleFile(
   const { code, map } = output.output[0];
 
   return {
-    code,
+    code: code + '//# sourceMapping' + `URL=${path.basename(opts.dest)}.map\n`,
     map,
     cache: bundle.cache,
   };


### PR DESCRIPTION
Closes #2172
