### PR TITLE
fix: close rollup bundle after write

### DIFF
--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -84,6 +84,9 @@ export async function rollupBundleFile(
 
   const { code, map } = output.output[0];
 
+  // Close the bundle to let plugins clean up their external processes or services
+  await bundle.close();
+
   return {
     code: code + '//# sourceMapping' + `URL=${path.basename(opts.dest)}.map\n`,
     map,


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
```

## Description

The rollup bundle must be closed once `write` is finished to let plugins clean up their external processes or services via the `closeBundle` hook, otherwise it can lead to memory leaks.

## Does this PR introduce a breaking change?

```
[x] No
```
