### PR TITLE
fix: link to angular 12 ivy docs

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -72,7 +72,7 @@ export async function initializeTsConfig(
       'Project is attempting to disable the Ivy compiler. ' +
         'Angular versions 13 and higher do not support View Engine compiler for libraries. ' +
         'The Ivy compiler will be used to build this project. ' +
-        '\nFor additional information or if the build fails, please see https://angular.io/guide/ivy',
+        '\nFor additional information or if the build fails, please see https://v12.angular.io/guide/ivy',
     );
 
     defaultTsConfigParsed.options.enableIvy = true;


### PR DESCRIPTION
Closes #2228

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Replacing a 404 ivy link with a pair of non 404 files pinned to angular 12 in the angular repository that relate to ivy.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
