### PR TITLE
fix: invalid browsers version ranges

### DIFF
--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -216,14 +216,13 @@ function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): strin
     // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
     if (browserName === 'ios_saf') {
       browserName = 'ios';
-      // browserslist also uses ranges for iOS Safari versions but only the lowest is required
-      // to perform minimum supported feature checks. esbuild also expects a single version.
-      [version] = version.split('-');
     }
 
-    if (browserName === 'ie') {
-      transformed.push('edge12');
-    } else if (esBuildSupportedBrowsers.has(browserName)) {
+    // browserslist uses ranges `15.2-15.3` versions but only the lowest is required
+    // to perform minimum supported feature checks. esbuild also expects a single version.
+    [version] = version.split('-');
+
+    if (esBuildSupportedBrowsers.has(browserName)) {
       if (browserName === 'safari' && version === 'TP') {
         // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
         // a Technology Preview (TP) of Safari is assumed to support all currently known features.


### PR DESCRIPTION
This issue address the Invalid version: `"15.2-15.3"` range. We previously only handled version ranges for `ios_safari`. Now, we handle such versions for all browsers.

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
