### PR TITLE
style: fix formatting in peerDependency warning

### DIFF
--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -270,7 +270,7 @@ function checkNonPeerDependencies(
     } else {
       spinner.warn(
         colors.yellow(
-          `Distributing npm packages with '${property}' is not recommended. Please consider adding ${dep}` +
+          `Distributing npm packages with '${property}' is not recommended. Please consider adding ${dep} ` +
             `to 'peerDependencies' or remove it from '${property}'.`,
         ),
       );


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

Fixes formatting in the peerDependency warning

<img width="1146" alt="Screenshot 2022-02-20 at 7 23 05 PM" src="https://user-images.githubusercontent.com/20282546/154845966-82b1d87b-8fc3-42eb-ae02-b70e2f0bd5ab.png">

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
