### PR TITLE
feat: drop support for Node.js 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scss"
   ],
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "author": "David Herges <david@spektrakel.de>",
   "license": "MIT",

--- a/src/lib/utils/fs.ts
+++ b/src/lib/utils/fs.ts
@@ -7,7 +7,7 @@ export const writeFile = fs.promises.writeFile;
 export const access = fs.promises.access;
 export const mkdir = fs.promises.mkdir;
 export const stat = fs.promises.stat;
-export const rmdir = fs.promises.rm ?? fs.promises.rmdir;
+export const rmdir = fs.promises.rm;
 
 export async function exists(path: fs.PathLike): Promise<boolean> {
   try {


### PR DESCRIPTION
Node.js v12 will become EOL on 2022-04-30. As a result, Angular CLI v14 will no longer support Node.js v12.

BREAKING CHANGE:

Support for Node.js v12 has been removed as it will become EOL on 2022-04-30. Please use Node.js v14.15 or later.
