### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/lib/graph/build-graph.ts
+++ b/src/lib/graph/build-graph.ts
@@ -46,7 +46,7 @@ export class BuildGraph implements Traversable<Node> {
     }
 
     if (this.watcher && node.url.startsWith(URL_PROTOCOL_FILE)) {
-      this.watcher.add(node.url.substr(URL_PROTOCOL_FILE.length));
+      this.watcher.add(node.url.slice(URL_PROTOCOL_FILE.length));
     }
 
     this.store.set(node.url, node);

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -244,7 +244,7 @@ function customSassImporter(url: string, prev: string): { file: string; prev: st
   }
 
   return {
-    file: url.substr(1),
+    file: url.slice(1),
     prev,
   };
 }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
