### PR TITLE
refactor: suppress rollup circular dependency warnings

### DIFF
--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -54,6 +54,7 @@ export async function rollupBundleFile(
     ],
     onwarn: warning => {
       switch (warning.code) {
+        case 'CIRCULAR_DEPENDENCY':
         case 'UNUSED_EXTERNAL_IMPORT':
         case 'THIS_IS_UNDEFINED':
           break;


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added (_N/A_)


## Description

In [this commit](https://github.com/angular/angular-cli/commit/0a1cd584d8ed00889b177f4284baec7e5427caf2) the `showCircularDependencies` option was removed from the `angular-cli`. This PR makes a corresponding change for `ng-packagr` that suppresses rollout's circular dependency warning during `ng build` as suggested in [this rollout issue](https://github.com/rollup/rollup/issues/2271#issuecomment-475540827).

**Why?**

Circular dependencies often lead to trouble, but sometimes they're a completely valid design tool that both compile and execute just fine. In that case, it doesn't make sense for `ng-packagr` to be emitting an unconfigurable warning when we already have configurable tools like [eslint](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) and [circular-dependency-plugin](https://github.com/aackerman/circular-dependency-plugin). It's unfortunate cause I'm sure this is a useful warning 95% of the time; but, having to tell folks "ignore warnings ABC from libraries XYZ" is a worse precedent, in my opinion.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
