### PR TITLE
fix: update watch version on secundary entrypoint changes

### DIFF
--- a/integration/watch/basic.spec.ts
+++ b/integration/watch/basic.spec.ts
@@ -64,6 +64,21 @@ describe('basic', () => {
           done();
         });
       });
+
+      it('should update `package.json` watch version', done => {
+        const originalVersion = harness.readFileSync('package.json', true)['version'];
+        expect(originalVersion).to.match(/^0\.0\.0-watch\+\d+$/);
+
+        harness.copyTestCase('secondary-valid-2');
+
+        harness.onComplete(() => {
+          const updatedVersion = harness.readFileSync('package.json', true)['version'];
+          expect(updatedVersion).to.match(/^0\.0\.0-watch\+\d+$/);
+          expect(originalVersion).to.not.be.equal(updatedVersion);
+
+          done();
+        });
+      });
     });
   });
 });

--- a/integration/watch/basic/test_files/secondary-valid-2/secondary/src/secondary.component.ts
+++ b/integration/watch/basic/test_files/secondary-valid-2/secondary/src/secondary.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ng-component',
+  template: 'Hello Angular 2',
+})
+export class SecondaryAngularComponent {}

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -5,7 +5,7 @@ import { BuildGraph } from '../../graph/build-graph';
 import { Node } from '../../graph/node';
 import { transformFromPromise } from '../../graph/transform';
 import { colors } from '../../utils/color';
-import { copyFile, rmdir, stat, writeFile } from '../../utils/fs';
+import { copyFile, exists, readFile, rmdir, stat, writeFile } from '../../utils/fs';
 import { globFiles } from '../../utils/glob';
 import * as log from '../../utils/log';
 import { ensureUnixPath } from '../../utils/path';
@@ -72,6 +72,18 @@ export const writePackageTransform = (options: NgPackagrOptions) =>
         throw error;
       }
       spinner.succeed();
+    } else if (options.watch) {
+      // update the watch version of the primary entry point `package.json` file.
+      // this is needed because of Webpack's 5 `cachemanagedpaths`
+      // https://github.com/ng-packagr/ng-packagr/issues/2069
+      const primary = ngPackageNode.data.primary;
+      const packageJsonPath = path.join(primary.destinationPath, 'package.json');
+
+      if (await exists(packageJsonPath)) {
+        const packageJson = JSON.parse(await readFile(packageJsonPath, { encoding: 'utf8' }));
+        packageJson.version = generateWatchVersion();
+        await writeFile(path.join(primary.destinationPath, 'package.json'), JSON.stringify(packageJson, undefined, 2));
+      }
     }
 
     spinner.succeed(`Built ${ngEntryPoint.moduleId}`);
@@ -190,7 +202,7 @@ async function writePackageJson(
   if (isWatchMode) {
     // Needed because of Webpack's 5 `cachemanagedpaths`
     // https://github.com/angular/angular-cli/issues/20962
-    packageJson.version = `0.0.0-watch+${Date.now()}`;
+    packageJson.version = generateWatchVersion();
   }
 
   if (!packageJson.peerDependencies?.tslib && !packageJson.dependencies?.tslib) {
@@ -371,4 +383,11 @@ function generatePackageExports({ destinationPath, packageJson }: NgEntryPoint, 
   }
 
   return exports;
+}
+
+/**
+ * Generates a new version for the package `package.json` when runing in watch mode.
+ */
+function generateWatchVersion() {
+  return `0.0.0-watch+${Date.now()}`;
 }


### PR DESCRIPTION
closes #2069

## I'm submitting a...

```
[X] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description

Currently, when a secondary entrypoint emits new changes, the `package.json` version is not updated, making linked libraries changes undetected by webpack.

With this change, we update the main entrypoint `package.json` version whenever a secondary entrypoint recompiles in watch mode.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
