### PR TITLE
feat: switch to sass modern API

### DIFF
--- a/integration/samples/material/baz/baz.component.scss
+++ b/integration/samples/material/baz/baz.component.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @include mat.core();
 
 .baz {

--- a/integration/samples/scss-paths/baz/baz.component.sass
+++ b/integration/samples/scss-paths/baz/baz.component.sass
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat
+@use '@angular/material' as mat
 
 @import 'baz.theme'
 @import 'baz.theme2'

--- a/integration/samples/scss-paths/baz/baz.component.scss
+++ b/integration/samples/scss-paths/baz/baz.component.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @import 'baz.theme';
 @import 'baz.theme2';
 @import 'theme';

--- a/integration/samples/secondary/primary/baz/baz.component.scss
+++ b/integration/samples/secondary/primary/baz/baz.component.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @include mat.core();
 
 .baz {


### PR DESCRIPTION


BREAKING CHANGE:

Deprecated support for tilde import has been removed. Please update the imports by removing the `~`.

Before
```scss
@import "~font-awesome/scss/font-awesome";
```

After
```scss
@import "font-awesome/scss/font-awesome";
```