### PR TITLE
fix: emit TypeScript declaration diagnostics

### DIFF
--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -118,6 +118,7 @@ export async function compileSourceFiles(
   for (const sourceFile of builder.getSourceFiles()) {
     if (!ignoreForDiagnostics.has(sourceFile)) {
       allDiagnostics.push(
+        ...builder.getDeclarationDiagnostics(sourceFile),
         ...builder.getSyntacticDiagnostics(sourceFile),
         ...builder.getSemanticDiagnostics(sourceFile),
       );


### PR DESCRIPTION
Previously, declaration diagnostics were not emitted which caused certain compilation errors not to be emitted.

Closes #2405
