### PR TITLE
Grammatical update for error message

### DIFF
--- a/src/lib/ng-package/entry-point/analyse-sources.transform.ts
+++ b/src/lib/ng-package/entry-point/analyse-sources.transform.ts
@@ -165,7 +165,7 @@ function analyseEntryPoint(graph: BuildGraph, entryPoint: EntryPointNode, entryP
 
       entryPoint.dependsOn(dep);
     } else {
-      throw new Error(`Entry point ${moduleName} which is required by ${moduleId} doesn't exists.`);
+      throw new Error(`Entry point ${moduleName} which is required by ${moduleId} doesn't exist.`);
     }
   }
 }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ x ] Other (Refactoring, Added tests, Documentation, ...)
```
## Description
Update wording of error message to use the word **exist** instead of **exists**

_Entry point `${moduleName}` which is required by `${moduleId}` doesn't exist._

See issue #2428

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```
