### PR TITLE
refactor: remove support for Stylus

### DIFF
--- a/integration/samples/custom/src/foo-bar/foo-bar.component.styl
+++ b/integration/samples/custom/src/foo-bar/foo-bar.component.styl
@@ -1,8 +1,0 @@
-@import "../styles/variables.styl"
-$color = red
-
-h1
-  color $color
-  background-color $color-green
-  background-image $image
-

--- a/integration/samples/custom/src/foo-bar/foo-bar.component.ts
+++ b/integration/samples/custom/src/foo-bar/foo-bar.component.ts
@@ -3,7 +3,6 @@ import { Component, ContentChild, ElementRef } from '@angular/core';
 @Component({
   selector: 'custom-foo-bar',
   templateUrl: './foo-bar.component.html',
-  styleUrls: ['./foo-bar.component.styl'],
 })
 export class FooBarComponent {
   @ContentChild('heading', { read: ElementRef, static: true })

--- a/integration/samples/scss-paths/assets/theme.styl
+++ b/integration/samples/scss-paths/assets/theme.styl
@@ -1,1 +1,0 @@
-$font-size-large = 32pt

--- a/integration/samples/scss-paths/baz/baz.component.styl
+++ b/integration/samples/scss-paths/baz/baz.component.styl
@@ -1,4 +1,0 @@
-@import "theme"
-
-.baz
-  font-size: $font-size-large

--- a/integration/samples/scss-paths/baz/baz.component.ts
+++ b/integration/samples/scss-paths/baz/baz.component.ts
@@ -4,7 +4,7 @@ import { someOtherFoo } from './baz.utils';
 @Component({
   selector: 'baz-component',
   templateUrl: './baz.component.html',
-  styleUrls: ['./baz.component.scss', './baz component.less', './baz.component.styl', './baz.component.sass'],
+  styleUrls: ['./baz.component.scss', './baz component.less', './baz.component.sass'],
 })
 export class BazComponent {
   constructor() {

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.styl
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.styl
@@ -1,5 +1,0 @@
-@import "theme"
-@require "common"
-
-.foo
-  font-sized(sans-serif, $font-size-large)

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.ts
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.ts
@@ -3,6 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'bar-component',
   templateUrl: './bar.component.html',
-  styleUrls: ['./bar.component.scss', './bar.component.less', './bar.component.styl', './bar.component.sass'],
+  styleUrls: ['./bar.component.scss', './bar.component.less', './bar.component.sass'],
 })
 export class BarComponent {}

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "rollup": "^2.70.0",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rxjs": "^7.5.5",
-    "sass": "^1.49.9",
-    "stylus": "^0.59.0"
+    "sass": "^1.49.9"
   },
   "optionalDependencies": {
     "esbuild": "^0.15.0"
@@ -86,7 +85,6 @@
     "@types/less": "^3.0.2",
     "@types/node": "^14.14.37",
     "@types/read-pkg-up": "^3.0.1",
-    "@types/stylus": "^0.48.30",
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
     "chai": "^4.0.1",
@@ -126,7 +124,6 @@
     "integration:consumers:ngc": "ngc -p integration/consumers/tsc/tsconfig.json",
     "integration:watch:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json jasmine-ts --random=false \"integration/watch/*.spec.ts\"",
     "test:specs": "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json jasmine-ts \"src/**/*.spec.ts\"",
-    "test": "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:watch:specs && yarn integration:consumers",
-    "gh-pages": "gh-pages -d docs/ghpages"
+    "test": "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:watch:specs && yarn integration:consumers"
   }
 }

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -173,22 +173,7 @@ export class StylesheetProcessor {
 
         return content;
       }
-      case '.styl':
-      case '.stylus': {
-        const stylus = (await import('stylus')).default;
 
-        return (
-          stylus(css)
-            // add paths for resolve
-            .set('paths', [this.basePath, '.', ...this.styleIncludePaths, 'node_modules'])
-            // add support for resolving plugins from node_modules
-            .set('filename', filePath)
-            // turn on url resolver in stylus, same as flag --resolve-url
-            .set('resolve url', true)
-            .define('url', stylus.resolver(undefined))
-            .render()
-        );
-      }
       case '.css':
       default:
         return css;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@adobe/css-tools@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
-  integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
-
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -764,13 +759,6 @@
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
-  dependencies:
-    "@types/node" "*"
-
-"@types/stylus@^0.48.30":
-  version "0.48.38"
-  resolved "https://registry.yarnpkg.com/@types/stylus/-/stylus-0.48.38.tgz#6e62a59f9350f53a253aa42b038b6aa44a642c5b"
-  integrity sha512-B5otJekvD6XM8iTrnO6e2twoTY2tKL9VkL/57/2Lo4tv3EatbCaufdi68VVtn/h4yjO+HVvYEyrNQd0Lzj6riw==
   dependencies:
     "@types/node" "*"
 
@@ -3935,7 +3923,7 @@ sass@^1.49.9:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -4005,11 +3993,6 @@ source-map@^0.6.1, source-map@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@^0.7.3:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
-  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 sourcemap-codec@^1.4.8:
   version "1.4.8"
@@ -4157,17 +4140,6 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-stylus@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.59.0.tgz#a344d5932787142a141946536d6e24e6a6be7aa6"
-  integrity sha512-lQ9w/XIOH5ZHVNuNbWW8D822r+/wBSO/d6XvtyHLF7LW4KaCIDeVbvn5DF8fGCJAUCwVhVi/h6J0NUcnylUEjg==
-  dependencies:
-    "@adobe/css-tools" "^4.0.1"
-    debug "^4.3.2"
-    glob "^7.1.6"
-    sax "~1.2.4"
-    source-map "^0.7.3"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
BREAKING CHANGE:

Deprecated support for Stylus has been removed. The Stylus package has never reached a stable version and it's usage in the ng-packagr is minimal. It's recommended to migrate to another CSS preprocessor that the ng-packagr supports.
