### PR TITLE
feat: drop support for TypeScript 4.6 and 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "@angular/compiler-cli": "^15.0.0-next",
     "tslib": "^2.3.0",
-    "typescript": ">=4.6.2 <4.9"
+    "typescript": "^4.8.2"
   },
   "devDependencies": {
     "@angular/cdk": "~14.2.0-next",


### PR DESCRIPTION
This commit drops support for TypeScript 4.6 and 4.7

BREAKING CHANGE: TypeScript versions older than 4.8.2 are no longer supported.
