### PR TITLE
fix: exclude scanning nested node_modules when locating `README.md`

### DIFF
--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -103,7 +103,7 @@ async function copyAssets(
   const globsForceIgnored: string[] = ['.gitkeep', '**/.DS_Store', '**/Thumbs.db', `${ngPackage.dest}/**`];
   const defaultAssets: AssetEntry[] = [
     { glob: 'LICENSE', input: '/', output: '/' },
-    { glob: '**/README.md', input: '/', output: '/', ignore: ['node_modules/**'] },
+    { glob: '**/README.md', input: '/', output: '/', ignore: ['**/node_modules/**'] },
   ];
   const assets: AssetEntry[] = [];
 


### PR DESCRIPTION
Closes #2459
