### PR TITLE
docs: mention the new asset copying syntax

### DIFF
--- a/docs/copy-assets.md
+++ b/docs/copy-assets.md
@@ -22,6 +22,11 @@ You can copy these assets by using the `assets` option.
 }
 ```
 
+Let's say you have a library `projects/my-lib`. With the config above, ng-packagr will copy `projects/my-lib/CHANGELOG.md` to `dist/my-lib/CHANGELOG.md` and copy all the SCSS files under `projects/my-lib/src/styles` to `dist/my-lib/styles`.
+
+Note that the advanced asset pattern, with a same syntax as Angular Builder's one, is used for SCSS files in the example above to allow a different output dir, so that we can put our styles under `projects/my-lib/src/styles` instead of `projects/my-lib/styles`.
+
+
 ## Exporting Styles
 When including additional assets like Sass mixins or pre-compiled CSS, you need to add these manually to the conditional "exports" in the `package.json` of the primary entry point.
 

--- a/docs/copy-assets.md
+++ b/docs/copy-assets.md
@@ -13,6 +13,7 @@ You can copy these assets by using the `assets` option.
   "ngPackage": {
     "assets": [
       "CHANGELOG.md",
+      "docs/**/*.md",
       { "input": "src/styles", "glob": "**/*.scss", "output": "styles" }
     ],
     "lib": {
@@ -21,8 +22,6 @@ You can copy these assets by using the `assets` option.
   }
 }
 ```
-
-Let's say you have a library `projects/my-lib`. With the config above, ng-packagr will copy `projects/my-lib/CHANGELOG.md` to `dist/my-lib/CHANGELOG.md` and copy all the SCSS files under `projects/my-lib/src/styles` to `dist/my-lib/styles`.
 
 Note that the advanced asset pattern, with a same syntax as Angular Builder's one, is used for SCSS files in the example above to allow a different output dir, so that we can put our styles under `projects/my-lib/src/styles` instead of `projects/my-lib/styles`.
 

--- a/docs/copy-assets.md
+++ b/docs/copy-assets.md
@@ -13,7 +13,7 @@ You can copy these assets by using the `assets` option.
   "ngPackage": {
     "assets": [
       "CHANGELOG.md",
-      "./styles/**/*.theme.scss"
+      { "input": "src/styles", "glob": "**/*.scss", "output": "styles" }
     ],
     "lib": {
       ...


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

There is a new advanced asset copying syntax introduced in the PR #2284. This syntax can be quite helpful for component libraries.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
