### PR TITLE
feat: add support for dynamic import

### DIFF
--- a/integration/samples/dynamic-imports/LICENSE
+++ b/integration/samples/dynamic-imports/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 Alan Agius
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integration/samples/dynamic-imports/README.md
+++ b/integration/samples/dynamic-imports/README.md
@@ -1,0 +1,3 @@
+# Sample library: Angular Package Format
+
+Library testing Angular Package Format

--- a/integration/samples/dynamic-imports/ng-package.json
+++ b/integration/samples/dynamic-imports/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public_api.ts"
+  }
+}

--- a/integration/samples/dynamic-imports/package.json
+++ b/integration/samples/dynamic-imports/package.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../src/package.schema.json",
+  "name": "@sample/dynamic-imports",
+  "description": "A sample library testing Angular Package Format",
+  "version": "1.0.0-pre.0",
+  "license": "MIT",
+  "private": true,
+  "repository": "https://github.com/ng-packagr/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/core": "^4.1.2",
+    "@angular/common": "^4.1.2"
+  },
+  "scripts": {
+    "test":
+      "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
+  },
+  "devDependencies": {
+    "@angular/compiler-cli": "^4.1.2"
+  }
+}

--- a/integration/samples/dynamic-imports/public_api.ts
+++ b/integration/samples/dynamic-imports/public_api.ts
@@ -1,0 +1,3 @@
+export { PrimaryAngularModule } from './src/primary.module';
+export { PrimaryAngularComponent } from './src/primary.component';
+export const title = 'hello world';

--- a/integration/samples/dynamic-imports/specs/files.ts
+++ b/integration/samples/dynamic-imports/specs/files.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import * as path from 'path';
+import * as glob from 'glob';
+import * as fs from 'fs';
+
+describe('@sample/dynamic-imports', () => {
+  let DIST: string;
+  beforeAll(() => {
+    DIST = path.resolve(__dirname, '../dist');
+  });
+
+  describe('FESM2020', () => {
+    it(`should contain 2 '.mjs.map' files`, () => {
+      expect(glob.sync(`fesm2020/**/*.mjs.map`, { cwd: DIST }).length).equal(2);
+    });
+
+    it(`should contain 2 '.mjs' files`, () => {
+      expect(glob.sync(`fesm2020/**/*.mjs`, { cwd: DIST }).length).equal(2);
+    });
+  });
+
+  describe('FESM2015', () => {
+    it(`should contain 2 '.mjs.map' files`, () => {
+      expect(glob.sync(`fesm2015/**/*.mjs.map`, { cwd: DIST }).length).equal(2);
+    });
+
+    it(`should contain 2 '.mjs' files`, () => {
+      expect(glob.sync(`fesm2015/**/*.mjs`, { cwd: DIST }).length).equal(2);
+    });
+  });
+
+  describe('fesm2020/sample-dynamic-imports.mjs', () => {
+    it(`should lazy import`, () => {
+      const content = fs.readFileSync(path.join(DIST, 'fesm2020/sample-dynamic-imports.mjs'), { encoding: 'utf-8' });
+      expect(content).to.match(/import\('\.\/sample-dynamic-imports-lazy-import-\w+\.mjs'\)/);
+    });
+  });
+
+  describe('fesm2015/sample-dynamic-imports.mjs', () => {
+    it(`should lazy import`, () => {
+      const content = fs.readFileSync(path.join(DIST, 'fesm2015/sample-dynamic-imports.mjs'), { encoding: 'utf-8' });
+      expect(content).to.match(/import\('\.\/sample-dynamic-imports-lazy-import-\w+\.mjs'\)/);
+    });
+  });
+});

--- a/integration/samples/dynamic-imports/src/primary.component.ts
+++ b/integration/samples/dynamic-imports/src/primary.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ng-component',
+  template: '<h1>Angular!</h1>',
+})
+export class PrimaryAngularComponent {}
+
+export const lazy = import('./sub/lazy-import');

--- a/integration/samples/dynamic-imports/src/primary.module.ts
+++ b/integration/samples/dynamic-imports/src/primary.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PrimaryAngularComponent } from './primary.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [PrimaryAngularComponent],
+  exports: [PrimaryAngularComponent],
+})
+export class PrimaryAngularModule {}

--- a/integration/samples/dynamic-imports/src/sub/lazy-import.ts
+++ b/integration/samples/dynamic-imports/src/sub/lazy-import.ts
@@ -1,0 +1,1 @@
+export const test = 'foo';

--- a/src/lib/ng-package/entry-point/entry-point.ts
+++ b/src/lib/ng-package/entry-point/entry-point.ts
@@ -15,6 +15,10 @@ export interface DestinationFiles {
   esm2020: string;
   /** Sub path of entrypoint distributable. */
   directory: string;
+  /** Absolute path of this entry point `FESM2020` directory */
+  fesm2020Dir: string;
+  /** Absolute path of this entry point `FESM2015` directory */
+  fesm2015Dir: string;
 }
 
 /**
@@ -95,6 +99,8 @@ export class NgEntryPoint {
       esm2020: pathJoinWithDest('esm2020', secondaryDir, `${flatModuleFile}.mjs`),
       fesm2020: pathJoinWithDest('fesm2020', `${flatModuleFile}.mjs`),
       fesm2015: pathJoinWithDest('fesm2015', `${flatModuleFile}.mjs`),
+      fesm2020Dir: pathJoinWithDest('fesm2020'),
+      fesm2015Dir: pathJoinWithDest('fesm2015'),
     };
   }
 


### PR DESCRIPTION
This commits add supports to process dynamic imports and output lazy chunks.

**NB:** This does not mean that lazy routing is a good idea to have in a library.  There are cases outside of routing why you might want to use dynamic imports.

Closes https://github.com/angular/angular-cli/issues/21358 and closes https://github.com/ng-packagr/ng-packagr/issues/2508
