### PR TITLE
build: expand peer dependency version range for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@angular/compiler-cli": "^15.0.0 || ^15.1.0-next.0 || ^15.2.0-next.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "tslib": "^2.3.0",
-    "typescript": "~4.8.2"
+    "typescript": ">=4.8.2 <5.0"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
Updates the peer dependency range to allow for TypeScript 4.9.