### PR TITLE
perf: move stylesheet processing into a worker pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jsonc-parser": "^3.2.0",
     "less": "^4.1.3",
     "ora": "^5.1.0",
+    "piscina": "^3.2.0",
     "postcss": "^8.4.16",
     "postcss-url": "^10.1.3",
     "rollup": "^3.0.0",

--- a/src/lib/ng-package/entry-point/compile-ngc.transform.ts
+++ b/src/lib/ng-package/entry-point/compile-ngc.transform.ts
@@ -20,12 +20,12 @@ export const compileNgcTransformFactory = (
       discardStdin: false,
     });
 
-    try {
-      const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
-      const entryPoint: EntryPointNode = entryPoints.find(isEntryPointInProgress());
-      const ngPackageNode: PackageNode = graph.find(isPackage);
-      const projectBasePath = ngPackageNode.data.primary.basePath;
+    const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
+    const entryPoint: EntryPointNode = entryPoints.find(isEntryPointInProgress());
+    const ngPackageNode: PackageNode = graph.find(isPackage);
+    const projectBasePath = ngPackageNode.data.primary.basePath;
 
+    try {
       // Add paths mappings for dependencies
       const tsConfig = setDependenciesTsConfigPaths(entryPoint.data.tsConfig, entryPoints);
 
@@ -74,6 +74,10 @@ export const compileNgcTransformFactory = (
     } catch (error) {
       spinner.fail();
       throw error;
+    } finally {
+      if (!options.watch) {
+        entryPoint.cache.stylesheetProcessor?.destroy();
+      }
     }
 
     spinner.succeed();

--- a/src/lib/styles/stylesheet-processor-worker.ts
+++ b/src/lib/styles/stylesheet-processor-worker.ts
@@ -1,0 +1,182 @@
+import autoprefixer from 'autoprefixer';
+import { extname, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { workerData } from 'node:worker_threads';
+import postcss from 'postcss';
+import postcssUrl from 'postcss-url';
+import { EsbuildExecutor } from '../esbuild/esbuild-executor';
+import { generateKey, readCacheEntry, saveCacheEntry } from '../utils/cache';
+import * as log from '../utils/log';
+import { CssUrl } from './stylesheet-processor';
+
+const { tailwindConfigPath, projectBasePath, browserslistData, targets, cssUrl, styleIncludePaths } = workerData as {
+  tailwindConfigPath: string | undefined;
+  browserslistData: string;
+  targets: string[];
+  projectBasePath: string;
+  cssUrl: CssUrl;
+  styleIncludePaths: string[];
+  cacheDirectory: string | undefined;
+};
+
+let cacheDirectory = workerData.cacheDirectory;
+let postCssProcessor: ReturnType<typeof postcss>;
+let esbuild: EsbuildExecutor;
+
+interface RenderRequest {
+  content: string;
+  filePath: string;
+}
+
+async function render({ content, filePath }: RenderRequest): Promise<string> {
+  let key: string | undefined;
+  if (cacheDirectory && !content.includes('@import') && !content.includes('@use')) {
+    // No transitive deps, we can cache more aggressively.
+    key = await generateKey(content, ...browserslistData);
+    const result = await readCacheEntry(cacheDirectory, key);
+    if (result) {
+      result.warnings.forEach(msg => log.warn(msg));
+
+      return result.css;
+    }
+  }
+
+  // Render pre-processor language (sass, styl, less)
+  const renderedCss = await renderCss(filePath, content);
+
+  // We cannot cache CSS re-rendering phase, because a transitive dependency via (@import) can case different CSS output.
+  // Example a change in a mixin or SCSS variable.
+  if (!key) {
+    key = await generateKey(renderedCss, ...browserslistData);
+  }
+
+  if (cacheDirectory) {
+    const cachedResult = await readCacheEntry(cacheDirectory, key);
+    if (cachedResult) {
+      cachedResult.warnings.forEach(msg => log.warn(msg));
+
+      return cachedResult.css;
+    }
+  }
+
+  // Render postcss (autoprefixing and friends)
+  const result = await postCssProcessor.process(renderedCss, {
+    from: filePath,
+    to: filePath.replace(extname(filePath), '.css'),
+  });
+
+  const warnings = result.warnings().map(w => w.toString());
+  const { code, warnings: esBuildWarnings } = await esbuild.transform(result.css, {
+    loader: 'css',
+    minify: true,
+    target: targets,
+    sourcefile: filePath,
+  });
+
+  if (esBuildWarnings.length > 0) {
+    warnings.push(...(await esbuild.formatMessages(esBuildWarnings, { kind: 'warning' })));
+  }
+
+  if (cacheDirectory) {
+    await saveCacheEntry(
+      cacheDirectory,
+      key,
+      JSON.stringify({
+        css: code,
+        warnings,
+      }),
+    );
+  }
+
+  warnings.forEach(msg => log.warn(msg));
+
+  return code;
+}
+
+async function renderCss(filePath: string, css: string): Promise<string> {
+  const ext = extname(filePath);
+
+  switch (ext) {
+    case '.sass':
+    case '.scss': {
+      return (await import('sass')).compileString(css, {
+        url: pathToFileURL(filePath),
+        syntax: '.sass' === ext ? 'indented' : 'scss',
+        loadPaths: styleIncludePaths,
+      }).css;
+    }
+    case '.less': {
+      const { css: content } = await (
+        await import('less')
+      ).default.render(css, {
+        filename: filePath,
+        math: 'always',
+        javascriptEnabled: true,
+        paths: styleIncludePaths,
+      });
+
+      return content;
+    }
+
+    case '.css':
+    default:
+      return css;
+  }
+}
+
+function getTailwindPlugin() {
+  // Attempt to setup Tailwind CSS
+  // Only load Tailwind CSS plugin if configuration file was found.
+  // This acts as a guard to ensure the project actually wants to use Tailwind CSS.
+  // The package may be unknowningly present due to a third-party transitive package dependency.
+  if (tailwindConfigPath) {
+    let tailwindPackagePath;
+    try {
+      tailwindPackagePath = require.resolve('tailwindcss', { paths: [projectBasePath] });
+    } catch {
+      const relativeTailwindConfigPath = relative(projectBasePath, tailwindConfigPath);
+      log.warn(
+        `Tailwind CSS configuration file found (${relativeTailwindConfigPath})` +
+          ` but the 'tailwindcss' package is not installed.` +
+          ` To enable Tailwind CSS, please install the 'tailwindcss' package.`,
+      );
+    }
+
+    if (tailwindPackagePath) {
+      return require(tailwindPackagePath)({ config: tailwindConfigPath });
+    }
+  }
+}
+
+async function initialize() {
+  const postCssPlugins = [];
+  const tailwinds = getTailwindPlugin();
+  if (tailwinds) {
+    postCssPlugins.push(tailwinds);
+    cacheDirectory = undefined;
+  }
+
+  if (cssUrl !== CssUrl.none) {
+    postCssPlugins.push(postcssUrl({ url: cssUrl }));
+  }
+
+  postCssPlugins.push(
+    autoprefixer({
+      ignoreUnknownVersions: true,
+      overrideBrowserslist: browserslistData,
+    }),
+  );
+
+  postCssProcessor = postcss(postCssPlugins);
+
+  esbuild = new EsbuildExecutor();
+
+  // Return the render function for use
+  return render;
+}
+
+/**
+ * The default export will be the promise returned by the initialize function.
+ * This is awaited by piscina prior to using the Worker.
+ */
+export default initialize();

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -1,43 +1,29 @@
-import autoprefixer from 'autoprefixer';
 import browserslist from 'browserslist';
-import { existsSync } from 'fs';
-import { dirname, extname, join, relative } from 'path';
-import postcss from 'postcss';
-import postcssUrl from 'postcss-url';
-import { pathToFileURL } from 'url';
-import { EsbuildExecutor } from '../esbuild/esbuild-executor';
-import { generateKey, readCacheEntry, saveCacheEntry } from '../utils/cache';
-import * as log from '../utils/log';
+import { dirname, join } from 'path';
+import Piscina from 'piscina';
+import { colors } from '../utils/color';
+import { exists } from '../utils/fs';
+
+const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
+const maxThreads = typeof maxWorkersVariable === 'string' && maxWorkersVariable !== '' ? +maxWorkersVariable : 4;
 
 export enum CssUrl {
   inline = 'inline',
   none = 'none',
 }
 
-export interface Result {
-  css: string;
-  warnings: string[];
-  error?: string;
-}
 export class StylesheetProcessor {
-  private browserslistData: string[];
-  private targets: string[];
-  private postCssProcessor: ReturnType<typeof postcss>;
-  private esbuild = new EsbuildExecutor();
-  private styleIncludePaths: string[];
-  private readonly nodeModulesDirs = [];
+  private renderWorker: Piscina | undefined;
 
   constructor(
     private readonly projectBasePath: string,
     private readonly basePath: string,
     private readonly cssUrl?: CssUrl,
     private readonly includePaths?: string[],
-    private cacheDirectory?: string | false,
+    private readonly cacheDirectory?: string | false,
   ) {
-    log.debug(`determine browserslist for ${this.basePath}`);
     // By default, browserslist defaults are too inclusive
     // https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522
-
     // We change the default query to browsers that Angular support.
     // https://angular.io/guide/browser-support
     (browserslist.defaults as string[]) = [
@@ -48,142 +34,57 @@ export class StylesheetProcessor {
       'last 2 iOS major versions',
       'Firefox ESR',
     ];
+  }
 
-    this.styleIncludePaths = [...this.includePaths];
+  async process({ filePath, content }: { filePath: string; content: string }): Promise<string> {
+    await this.getOrCreateRenderWorker();
+
+    return this.renderWorker.run({ content, filePath });
+  }
+
+  /** Destory workers in pool. */
+  destroy(): void {
+    void this.renderWorker?.destroy();
+  }
+
+  private async getOrCreateRenderWorker(): Promise<void> {
+    if (this.renderWorker) {
+      return;
+    }
+
+    const styleIncludePaths = [...this.includePaths];
     let prevDir = null;
     let currentDir = this.basePath;
 
     while (currentDir !== prevDir) {
       const p = join(currentDir, 'node_modules');
-      if (existsSync(p)) {
-        this.styleIncludePaths.push(p);
-        this.nodeModulesDirs.push(p);
+      if (await exists(p)) {
+        styleIncludePaths.push(p);
       }
 
       prevDir = currentDir;
       currentDir = dirname(prevDir);
     }
 
-    this.browserslistData = browserslist(undefined, { path: this.basePath });
-    this.targets = transformSupportedBrowsersToTargets(this.browserslistData);
-    this.postCssProcessor = this.createPostCssPlugins();
-  }
+    const browserslistData = browserslist(undefined, { path: this.basePath });
 
-  async process({ filePath, content }: { filePath: string; content: string }): Promise<string> {
-    let key: string | undefined;
-
-    if (!content.includes('@import') && !content.includes('@use') && this.cacheDirectory) {
-      // No transitive deps, we can cache more aggressively.
-      key = await generateKey(content, ...this.browserslistData);
-      const result = await readCacheEntry(this.cacheDirectory, key);
-      if (result) {
-        result.warnings.forEach(msg => log.warn(msg));
-
-        return result.css;
-      }
-    }
-
-    // Render pre-processor language (sass, styl, less)
-    const renderedCss = await this.renderCss(filePath, content);
-
-    // We cannot cache CSS re-rendering phase, because a transitive dependency via (@import) can case different CSS output.
-    // Example a change in a mixin or SCSS variable.
-    if (!key) {
-      key = await generateKey(renderedCss, ...this.browserslistData);
-    }
-
-    if (this.cacheDirectory) {
-      const cachedResult = await readCacheEntry(this.cacheDirectory, key);
-      if (cachedResult) {
-        cachedResult.warnings.forEach(msg => log.warn(msg));
-
-        return cachedResult.css;
-      }
-    }
-    // Render postcss (autoprefixing and friends)
-    const result = await this.postCssProcessor.process(renderedCss, {
-      from: filePath,
-      to: filePath.replace(extname(filePath), '.css'),
+    this.renderWorker = new Piscina({
+      filename: require.resolve('./stylesheet-processor-worker'),
+      maxThreads,
+      env: {
+        ...process.env,
+        FORCE_COLOR: '' + colors.enabled,
+      },
+      workerData: {
+        tailwindConfigPath: await getTailwindConfigPath(this.projectBasePath),
+        projectBasePath: this.projectBasePath,
+        browserslistData,
+        targets: transformSupportedBrowsersToTargets(browserslistData),
+        cacheDirectory: this.cacheDirectory,
+        cssUrl: this.cssUrl,
+        styleIncludePaths: styleIncludePaths,
+      },
     });
-
-    const warnings = result.warnings().map(w => w.toString());
-    const { code, warnings: esBuildWarnings } = await this.esbuild.transform(result.css, {
-      loader: 'css',
-      minify: true,
-      target: this.targets,
-      sourcefile: filePath,
-    });
-
-    if (esBuildWarnings.length > 0) {
-      warnings.push(...(await this.esbuild.formatMessages(esBuildWarnings, { kind: 'warning' })));
-    }
-
-    if (this.cacheDirectory) {
-      await saveCacheEntry(
-        this.cacheDirectory,
-        key,
-        JSON.stringify({
-          css: code,
-          warnings,
-        }),
-      );
-    }
-    warnings.forEach(msg => log.warn(msg));
-
-    return code;
-  }
-
-  private createPostCssPlugins(): ReturnType<typeof postcss> {
-    const postCssPlugins = [];
-    const tailwinds = getTailwindPlugin(this.projectBasePath);
-    if (tailwinds) {
-      postCssPlugins.push(tailwinds);
-      this.cacheDirectory = false;
-    }
-
-    if (this.cssUrl !== CssUrl.none) {
-      postCssPlugins.push(postcssUrl({ url: this.cssUrl }));
-    }
-
-    postCssPlugins.push(
-      autoprefixer({
-        ignoreUnknownVersions: true,
-        overrideBrowserslist: this.browserslistData,
-      }),
-    );
-
-    return postcss(postCssPlugins);
-  }
-
-  private async renderCss(filePath: string, css: string): Promise<string> {
-    const ext = extname(filePath);
-
-    switch (ext) {
-      case '.sass':
-      case '.scss': {
-        return (await import('sass')).compileString(css, {
-          url: pathToFileURL(filePath),
-          syntax: '.sass' === ext ? 'indented' : 'scss',
-          loadPaths: this.styleIncludePaths,
-        }).css;
-      }
-      case '.less': {
-        const { css: content } = await (
-          await import('less')
-        ).default.render(css, {
-          filename: filePath,
-          math: 'always',
-          javascriptEnabled: true,
-          paths: this.styleIncludePaths,
-        });
-
-        return content;
-      }
-
-      case '.css':
-      default:
-        return css;
-    }
   }
 }
 
@@ -219,31 +120,7 @@ function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): strin
   return transformed.length ? transformed : undefined;
 }
 
-function getTailwindPlugin(projectBasePath: string) {
-  // Attempt to setup Tailwind CSS
-  // Only load Tailwind CSS plugin if configuration file was found.
-  // This acts as a guard to ensure the project actually wants to use Tailwind CSS.
-  // The package may be unknowningly present due to a third-party transitive package dependency.
-  const tailwindConfigPath = getTailwindConfigPath(projectBasePath);
-  if (tailwindConfigPath) {
-    let tailwindPackagePath;
-    try {
-      tailwindPackagePath = require.resolve('tailwindcss', { paths: [projectBasePath] });
-    } catch {
-      const relativeTailwindConfigPath = relative(projectBasePath, tailwindConfigPath);
-      log.warn(
-        `Tailwind CSS configuration file found (${relativeTailwindConfigPath})` +
-          ` but the 'tailwindcss' package is not installed.` +
-          ` To enable Tailwind CSS, please install the 'tailwindcss' package.`,
-      );
-    }
-    if (tailwindPackagePath) {
-      return require(tailwindPackagePath)({ config: tailwindConfigPath });
-    }
-  }
-}
-
-function getTailwindConfigPath(projectRoot: string): string | undefined {
+async function getTailwindConfigPath(projectRoot: string): Promise<string | undefined> {
   // A configuration file can exist in the project or workspace root
   // The list of valid config files can be found:
   // https://github.com/tailwindlabs/tailwindcss/blob/8845d112fb62d79815b50b3bae80c317450b8b92/src/util/resolveConfigPath.js#L46-L52
@@ -251,7 +128,7 @@ function getTailwindConfigPath(projectRoot: string): string | undefined {
   for (const configFile of tailwindConfigFiles) {
     // Irrespective of the name project level configuration should always take precedence.
     const fullPath = join(projectRoot, configFile);
-    if (existsSync(fullPath)) {
+    if (await exists(fullPath)) {
       return fullPath;
     }
   }

--- a/src/tsconfig.packagr.json
+++ b/src/tsconfig.packagr.json
@@ -6,6 +6,6 @@
     "skipLibCheck": true, // due to: https://github.com/angular/angular/issues/23112
     "types": ["node"]
   },
-  "files": ["cli/main.ts", "public_api.ts"],
+  "files": ["cli/main.ts", "public_api.ts", "./lib/styles/stylesheet-processor-worker.ts"],
   "exclude": ["**/*.spec.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,6 +124,11 @@
   dependencies:
     tslib "^2.3.0"
 
+"@assemblyscript/loader@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
+  integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1880,7 +1885,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
+base64-js@^1.2.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2917,6 +2922,11 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+eventemitter-asyncresource@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz#734ff2e44bf448e627f7748f905d6bdd57bdb65b"
+  integrity sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ==
+
 execa@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
@@ -3369,6 +3379,20 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hdr-histogram-js@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz#0b860534655722b6e3f3e7dca7b78867cf43dcb5"
+  integrity sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==
+  dependencies:
+    "@assemblyscript/loader" "^0.10.1"
+    base64-js "^1.2.0"
+    pako "^1.0.3"
+
+hdr-histogram-percentiles-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz#9409f4de0c2dda78e61de2d9d78b1e9f3cba283c"
+  integrity sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -4226,6 +4250,24 @@ next-tick@1, next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
+nice-napi@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nice-napi/-/nice-napi-1.0.2.tgz#dc0ab5a1eac20ce548802fc5686eaa6bc654927b"
+  integrity sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==
+  dependencies:
+    node-addon-api "^3.0.0"
+    node-gyp-build "^4.2.2"
+
+node-addon-api@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-gyp-build@^4.2.2:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
+  integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
+
 node-releases@^2.0.6:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.8.tgz#0f349cdc8fcfa39a92ac0be9bc48b7706292b9ae"
@@ -4414,6 +4456,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pako@^1.0.3:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -4517,6 +4564,17 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+piscina@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/piscina/-/piscina-3.2.0.tgz#f5a1dde0c05567775690cccefe59d9223924d154"
+  integrity sha512-yn/jMdHRw+q2ZJhFhyqsmANcbF6V2QwmD84c6xRau+QpQOmtrBCoRGdvTfeuFDYXB5W2m6MfLkjkvQa9lUSmIA==
+  dependencies:
+    eventemitter-asyncresource "^1.0.0"
+    hdr-histogram-js "^2.0.1"
+    hdr-histogram-percentiles-obj "^3.0.0"
+  optionalDependencies:
+    nice-napi "^1.0.2"
 
 pkg-dir@^4.1.0:
   version "4.2.0"


### PR DESCRIPTION
Stylesheets will now be processed using a worker pool This allows up to four stylesheets to be processed in parallel and keeps the main thread available for other build tasks.

`NG_BUILD_MAX_WORKERS` environment variable can be used to comfigure the limit of workers used.
