### PR TITLE
fix: remove trailing slash from dest

### DIFF
--- a/src/lib/ng-package/package.ts
+++ b/src/lib/ng-package/package.ts
@@ -58,7 +58,9 @@ export class NgPackage {
 
   /** Absolute path of the package's destination directory. */
   public get dest(): string {
-    return path.join(this.basePath, this.primary.$get('dest'));
+    const dest = path.join(this.basePath, this.primary.$get('dest'));
+
+    return dest.endsWith('/') ? dest.slice(0, -1) : dest;
   }
 
   public get keepLifecycleScripts(): boolean {


### PR DESCRIPTION
The trailing slash causes the watcher to go in an infinite loop.

Closes #2558
