### PR TITLE
refactor: remove Node.js v14 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ commands:
           at: ~/repo
   setup_windows:
     steps:
-      - run: nvm install 14.20
-      - run: nvm use 14.20
+      - run: nvm install 16.13
+      - run: nvm use 16.13
       - run: npm install -g yarn@1.22.10
       - run: node --version
       - run: yarn --version
@@ -27,7 +27,7 @@ commands:
 executors:
   linux-executor:
     docker:
-      - image: cimg/node:14.20
+      - image: cimg/node:16.13
     working_directory: ~/repo
 
 jobs:
@@ -38,11 +38,11 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v8-dependencies-linux-{{ checksum "yarn.lock" }}
+            - v1-dependencies-linux-{{ checksum "yarn.lock" }}
       # Install dependencies
       - run: yarn install --frozen-lockfile --non-interactive
       - save_cache:
-          key: v8-dependencies-linux-{{ checksum "yarn.lock" }}
+          key: v1-dependencies-linux-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       - persist_to_workspace:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scss"
   ],
   "engines": {
-    "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
+    "node": "^16.13.0 || >=18.10.0"
   },
   "author": "David Herges <david@spektrakel.de>",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v14 support has been removed

Node.js v14 is planned to be End-of-Life on 2023-04-30. Angular will stop supporting Node.js v14 in Angular v16. Angular v16 will continue to officially support Node.js versions v16 and v18.
