### PR TITLE
build: update minimum supported Node version from 16.13.0 -> 16.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ commands:
           at: ~/repo
   setup_windows:
     steps:
-      - run: nvm install 16.13
-      - run: nvm use 16.13
+      - run: nvm install 16.14
+      - run: nvm use 16.14
       - run: npm install -g yarn@1.22.10
       - run: node --version
       - run: yarn --version
@@ -27,7 +27,7 @@ commands:
 executors:
   linux-executor:
     docker:
-      - image: cimg/node:16.13
+      - image: cimg/node:16.14
     working_directory: ~/repo
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scss"
   ],
   "engines": {
-    "node": "^16.13.0 || >=18.10.0"
+    "node": "^16.14.0 || >=18.10.0"
   },
   "author": "David Herges <david@spektrakel.de>",
   "license": "MIT",


### PR DESCRIPTION
This commit updates the minimum supported Node version across packages from 16.13.0 -> 16.14.0 to ensure compatibility with dependencies.
