### PR TITLE
fix: do not set less math option

### DIFF
--- a/src/lib/styles/stylesheet-processor-worker.ts
+++ b/src/lib/styles/stylesheet-processor-worker.ts
@@ -112,7 +112,6 @@ async function renderCss(filePath: string, css: string): Promise<string> {
         await import('less')
       ).default.render(css, {
         filename: filePath,
-        math: 'always',
         javascriptEnabled: true,
         paths: styleIncludePaths,
       });


### PR DESCRIPTION
This change aligns the option with that of the Angular CLI as it caused unexpected output.

Closes #2675
