### PR TITLE
fix: watch mode not emitted transformed DTS files

### DIFF
--- a/src/lib/ng-package/entry-point/analyse-sources.transform.ts
+++ b/src/lib/ng-package/entry-point/analyse-sources.transform.ts
@@ -54,7 +54,6 @@ function analyseEntryPoint(graph: BuildGraph, entryPoint: EntryPointNode, entryP
     moduleResolutionCache,
     undefined,
     undefined,
-    undefined,
     analysesSourcesFileCache,
   );
 

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -33,13 +33,11 @@ export async function compileSourceFiles(
     );
   }
 
-  const emittedFiles = new Set<string>();
   const tsCompilerHost = cacheCompilerHost(
     graph,
     entryPoint,
     tsConfigOptions,
     moduleResolutionCache,
-    emittedFiles,
     stylesheetProcessor,
     inlineStyleLanguage,
   );
@@ -188,25 +186,13 @@ export async function compileSourceFiles(
     log.msg(formatDiagnostics(errorDiagnostics));
   }
 
-  const transformers = angularCompiler.prepareEmit().transformers;
-  if ('getSemanticDiagnosticsOfNextAffectedFile' in builder) {
-    // TypeScript will loop until there are no more affected files in the program
-    while (builder.emitNextAffectedFile(undefined, undefined, undefined, transformers)) {
-      // empty
-    }
-  }
-
   if (errorDiagnostics.length) {
     throw new Error(formatDiagnostics(errorDiagnostics));
   }
 
+  const transformers = angularCompiler.prepareEmit().transformers;
   for (const sourceFile of builder.getSourceFiles()) {
     if (ignoreForEmit.has(sourceFile)) {
-      continue;
-    }
-
-    if (emittedFiles.has(sourceFile.fileName)) {
-      angularCompiler.incrementalCompilation.recordSuccessfulEmit(sourceFile);
       continue;
     }
 

--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -18,7 +18,6 @@ export function cacheCompilerHost(
   entryPoint: EntryPointNode,
   compilerOptions: CompilerOptions,
   moduleResolutionCache: ts.ModuleResolutionCache,
-  emittedFiles?: Set<string>,
   stylesheetProcessor?: StylesheetProcessor,
   inlineStyleLanguage?: NgPackageConfig['inlineStyleLanguage'],
   sourcesFileCache: FileCache = entryPoint.cache.sourcesFileCache,
@@ -104,7 +103,6 @@ export function cacheCompilerHost(
         }
 
         sourceFiles.forEach(source => {
-          emittedFiles?.add(source.fileName);
           const cache = sourcesFileCache.getOrCreate(source.fileName);
           if (!cache.declarationFileName) {
             cache.declarationFileName = ensureUnixPath(fileName);
@@ -126,10 +124,6 @@ export function cacheCompilerHost(
           content: data,
           version,
           map,
-        });
-
-        sourceFiles.forEach(source => {
-          emittedFiles?.add(source.fileName);
         });
       }
 


### PR DESCRIPTION
It appears that `builder.emitNextAffectedFile` causes the afterDeclaration transformer not to run which causes the DTS files to be emitted without Angular metadata.

Closes #2664 and closes https://github.com/angular/angular-cli/issues/25706
