### PR TITLE
fix: emit `.tsbuildinfo` when cache mode is enabled

### DIFF
--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -191,6 +191,19 @@ export async function compileSourceFiles(
   }
 
   const transformers = angularCompiler.prepareEmit().transformers;
+
+  if ('getSemanticDiagnosticsOfNextAffectedFile' in builder) {
+    while (
+      builder.emitNextAffectedFile((fileName, data, writeByteOrderMark, onError, sourceFiles) => {
+        if (fileName.endsWith('.tsbuildinfo')) {
+          tsCompilerHost.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
+        }
+      })
+    ) {
+      // empty
+    }
+  }
+
   for (const sourceFile of builder.getSourceFiles()) {
     if (ignoreForEmit.has(sourceFile)) {
       continue;


### PR DESCRIPTION
Change #2682 caused an incorrect behaviour that caused the tsbuild info not to be emitted.
