### PR TITLE
feat: drop support for TypeScript versions before 5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "esbuild": "^0.19.0"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^17.0.0-next.0",
+    "@angular/compiler-cli": "^17.0.0 || ^17.0.0-next.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=4.9.3 <5.3"
+    "typescript": ">=5.2 <5.3"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
BREAKING CHANGE:  TypeScript versions before 5.2 are no longer supported.
