### PR TITLE
fix:Update copy-assets.md to reflect ng-package.json format

### DIFF
--- a/docs/copy-assets.md
+++ b/docs/copy-assets.md
@@ -6,19 +6,18 @@ As a library author you may want to distribute certain assets that are outside o
 
 ## How?
 
-You can copy these assets by using the `assets` option.
+You can copy these assets by using the `assets` option in ng-package.json.
 
 ```json
 {
-  "ngPackage": {
-    "assets": [
-      "CHANGELOG.md",
-      "docs/**/*.md",
-      { "input": "src/styles", "glob": "**/*.scss", "output": "styles" }
-    ],
-    "lib": {
-      ...
-    }
+  "$schema": "...",
+  "assets": [
+    "CHANGELOG.md",
+    "docs/**/*.md",
+    { "input": "src/styles", "glob": "**/*.scss", "output": "styles" }
+  ],
+  "lib": {
+    ...
   }
 }
 ```


### PR DESCRIPTION
small tweak so the documentation is up to date with ng-packagr schema

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[X ] Other (Refactoring, Added tests, Documentation, ...)
```



## Description

I found the documentation was reflecting old behavior of ng-packagr in its format for copying assets


## Does this PR introduce a breaking change?

```
[ ] Yes
[X ] No
```
