### PR TITLE
feat: esbuild can't resolve secondary entry point from library

### DIFF
--- a/integration/samples/apf/specs/files.ts
+++ b/integration/samples/apf/specs/files.ts
@@ -10,11 +10,11 @@ describe('@sample/apf', () => {
   });
 
   describe('dist', () => {
-    it('should contain a total of 45 files', () => {
+    it('should contain a total of 48 files', () => {
       // this is a safe guard / alternative to snapshots in order to
       // protect ourselves from doing a change that will emit unexpected files.
       const files = sync('**/*', { cwd: DIST });
-      expect(files.length).to.equals(45);
+      expect(files.length).to.equals(48);
     });
 
     it(`should contain a README.md file`, () => {

--- a/integration/samples/issue-1451/specs/license.ts
+++ b/integration/samples/issue-1451/specs/license.ts
@@ -22,8 +22,8 @@ describe(`issue-1451-license`, () => {
       });
     });
 
-    it(`license directory should contain 2 files`, () => {
-      expect(sync(`license/**/*`, { cwd: DIST }).length).equal(2);
+    it(`license directory should contain 3 files`, () => {
+      expect(sync(`license/**/*`, { cwd: DIST }).length).equal(3);
     });
   });
 });

--- a/integration/samples/keep-output-path/dest/.npmignore
+++ b/integration/samples/keep-output-path/dest/.npmignore
@@ -1,0 +1,2 @@
+# Nested package.json are only needed for development.
+**/package.json


### PR DESCRIPTION
This commit adds `package.json` in secondary entry-points so that esbuild can resolve secondary entry-points when the library is not in node_modules. Example, when it's being locally build.

Closes: https://github.com/angular/angular-cli/issues/24434
