### PR TITLE
fix: remove direct imports to `rollup`

### DIFF
--- a/src/lib/commands/version.command.ts
+++ b/src/lib/commands/version.command.ts
@@ -1,4 +1,3 @@
-import { VERSION as ROLLUP_VERSION } from 'rollup';
 import { version as TS_VERSION } from 'typescript';
 import { ngCompilerCli } from '../utils/load-esm';
 import { msg } from '../utils/log';
@@ -12,6 +11,5 @@ import { Command } from './command';
 export const version: Command<any, Promise<void>> = async () => {
   msg(`ng-packagr:            ` + require('../../package.json').version);
   msg(`@angular/compiler:     ` + (await ngCompilerCli()).VERSION.full);
-  msg(`rollup:                ` + ROLLUP_VERSION);
   msg(`typescript:            ` + TS_VERSION);
 };

--- a/src/lib/flatten/file-loader-plugin.ts
+++ b/src/lib/flatten/file-loader-plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 import { OutputFileCache } from '../ng-package/nodes';
 
 import * as log from '../utils/log';

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -1,6 +1,6 @@
 import ora from 'ora';
 import { join } from 'path';
-import { OutputAsset, OutputChunk, RollupCache } from 'rollup';
+import type { OutputAsset, OutputChunk, RollupCache } from 'rollup';
 import { rollupBundleFile } from '../../flatten/rollup';
 import { transformFromPromise } from '../../graph/transform';
 import { generateKey, readCacheEntry, saveCacheEntry } from '../../utils/cache';

--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -1,5 +1,5 @@
 import type { NgtscProgram, ParsedConfiguration, Program } from '@angular/compiler-cli';
-import { RollupCache } from 'rollup';
+import type { RollupCache } from 'rollup';
 import ts from 'typescript';
 import { FileCache } from '../file-system/file-cache';
 import { ComplexPredicate } from '../graph/build-graph';


### PR DESCRIPTION
Closes: https://github.com/ng-packagr/ng-packagr/issues/2749