### PR TITLE
fix: add missing tailwind `@screen` directive in matcher

### DIFF
--- a/src/lib/styles/stylesheet-processor-worker.ts
+++ b/src/lib/styles/stylesheet-processor-worker.ts
@@ -33,7 +33,15 @@ const CACHE_KEY_VALUES = [...browserslistData, ...styleIncludePaths, cssUrl].joi
  *
  * Based on https://tailwindcss.com/docs/functions-and-directives
  */
-const TAILWIND_KEYWORDS = ['@tailwind', '@layer', '@apply', '@config', 'theme(', 'screen('];
+const TAILWIND_KEYWORDS = [
+  '@tailwind',
+  '@layer',
+  '@apply',
+  '@config',
+  'theme(',
+  'screen(',
+  '@screen', // Undocumented in version 3, see: https://github.com/tailwindlabs/tailwindcss/discussions/7516.
+];
 
 async function render({ content, filePath }: RenderRequest): Promise<string> {
   let key: string | undefined;


### PR DESCRIPTION
`@screen` is not documented in tailwind documentation as it is not a recommended option, however it still works and they don't have plans to remove it.

https://github.com/tailwindlabs/tailwindcss/discussions/7516
