### PR TITLE
feat: support using custom postcss configuration

### DIFF
--- a/src/lib/styles/postcss-configuration.ts
+++ b/src/lib/styles/postcss-configuration.ts
@@ -1,0 +1,101 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface PostcssConfiguration {
+  plugins: [name: string, options?: object][];
+}
+
+interface RawPostcssConfiguration {
+  plugins?: Record<string, object | boolean> | (string | [string, object])[];
+}
+
+const postcssConfigurationFiles: string[] = ['postcss.config.json', '.postcssrc.json'];
+
+interface SearchDirectory {
+  root: string;
+  files: Set<string>;
+}
+
+async function generateSearchDirectories(roots: string[]): Promise<SearchDirectory[]> {
+  return await Promise.all(
+    roots.map(root =>
+      readdir(root, { withFileTypes: true }).then(entries => ({
+        root,
+        files: new Set(entries.filter(entry => entry.isFile()).map(entry => entry.name)),
+      })),
+    ),
+  );
+}
+
+function findFile(searchDirectories: SearchDirectory[], potentialFiles: string[]): string | undefined {
+  for (const { root, files } of searchDirectories) {
+    for (const potential of potentialFiles) {
+      if (files.has(potential)) {
+        return join(root, potential);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+async function readPostcssConfiguration(configurationFile: string): Promise<RawPostcssConfiguration> {
+  const data = await readFile(configurationFile, 'utf-8');
+  const config = JSON.parse(data) as RawPostcssConfiguration;
+
+  return config;
+}
+
+export async function loadPostcssConfiguration(
+  projectRoot: string,
+): Promise<PostcssConfiguration | undefined> {
+  // A configuration file can exist in the project or workspace root
+  const searchDirectories = await generateSearchDirectories([projectRoot]);
+
+  const configPath = findFile(searchDirectories, postcssConfigurationFiles);
+  if (!configPath) {
+    return undefined;
+  }
+
+  const raw = await readPostcssConfiguration(configPath);
+
+  // If no plugins are defined, consider it equivalent to no configuration
+  if (!raw.plugins || typeof raw.plugins !== 'object') {
+    return undefined;
+  }
+
+  // Normalize plugin array form
+  if (Array.isArray(raw.plugins)) {
+    if (raw.plugins.length < 1) {
+      return undefined;
+    }
+
+    const config: PostcssConfiguration = { plugins: [] };
+    for (const element of raw.plugins) {
+      if (typeof element === 'string') {
+        config.plugins.push([element]);
+      } else {
+        config.plugins.push(element);
+      }
+    }
+
+    return config;
+  }
+
+  // Normalize plugin object map form
+  const entries = Object.entries(raw.plugins);
+  if (entries.length < 1) {
+    return undefined;
+  }
+
+  const config: PostcssConfiguration = { plugins: [] };
+  for (const [name, options] of entries) {
+    if (!options || typeof options !== 'object') {
+      continue;
+    }
+
+    config.plugins.push([name, options]);
+  }
+
+  return config;
+}

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 import Piscina from 'piscina';
 import { colors } from '../utils/color';
+import { loadPostcssConfiguration } from './postcss-configuration';
 
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 const maxThreads = typeof maxWorkersVariable === 'string' && maxWorkersVariable !== '' ? +maxWorkersVariable : 4;
@@ -37,7 +38,7 @@ export class StylesheetProcessor {
   }
 
   async process({ filePath, content }: { filePath: string; content: string }): Promise<string> {
-    this.createRenderWorker();
+    await this.createRenderWorker();
 
     return this.renderWorker.run({ content, filePath });
   }
@@ -47,7 +48,7 @@ export class StylesheetProcessor {
     void this.renderWorker?.destroy();
   }
 
-  private createRenderWorker(): void {
+  private async createRenderWorker(): Promise<void> {
     if (this.renderWorker) {
       return;
     }
@@ -76,6 +77,7 @@ export class StylesheetProcessor {
         FORCE_COLOR: '' + colors.enabled,
       },
       workerData: {
+        postcssConfiguration: await loadPostcssConfiguration(this.projectBasePath),
         tailwindConfigPath: getTailwindConfigPath(this.projectBasePath),
         projectBasePath: this.projectBasePath,
         browserslistData,


### PR DESCRIPTION
The usage of a custom postcss configuration is now supported.

The builder will automatically detect and use specific postcss configuration files if present in either the project root directory. Files present in the project root will have priority over a workspace root file. If using a custom postcss configuration file, the automatic tailwind integration will be disabled. To use both a custom postcss configuration and tailwind, the tailwind setup must be included in the custom postcss configuration file.

The configuration files must be JSON and named one of the following:
* `postcss.config.json`
* `.postcssrc.json`

A configuration file can use either an array form or an object form to setup plugins.

An example of the array form:
```json
{
    "plugins": [
        "tailwindcss",
        ["rtlcss", { "useCalc": true }]
    ]
}
```

The same in an object form:
```json
{
    "plugins": {
        "tailwindcss": {},
        "rtlcss": { "useCalc": true }
    }
}
```

NOTE: Using a custom postcss configuration may result in reduced build and rebuild performance. Postcss will be used to process all global and component stylesheets when a custom configuration is present. Without a custom postcss configuration, postcss is only used for a stylesheet when tailwind is enabled and the stylesheet requires tailwind processing.

Closes #2765 and closes #643
