### PR TITLE
refactor: remove support for Node.js versions <18.19.1 and <20.11.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ commands:
           at: ~/repo
   setup_windows:
     steps:
-      - run: nvm install 18.13.0
-      - run: nvm use 18.13.0
+      - run: nvm install 18.19
+      - run: nvm use 18.19
       - run: npm install -g yarn@1.22.19
       - run: node --version
       - run: yarn --version
@@ -27,7 +27,7 @@ commands:
 executors:
   linux-executor:
     docker:
-      - image: cimg/node:18.13
+      - image: cimg/node:18.19
     working_directory: ~/repo
 
 jobs:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,1 @@
-renovate.json
-package.json
 package-lock.json
-README.md
-CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scss"
   ],
   "engines": {
-    "node": "^18.13.0 || >=20.9.0"
+    "node": "^18.19.1 || >=20.11.1"
   },
   "author": "David Herges <david@spektrakel.de>",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE: Node.js support for versions <18.19.1 and <20.11.1 has been removed.
