### PR TITLE
build: narrow down supported TypeScript versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@angular/compiler-cli": "^18.0.0-next.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.2 <5.5"
+    "typescript": ">=5.4 <5.5"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
In angular/angular#54961 the Angular compiler stopped supporting TypeScript versions older than 5.4. These changes narrow down the range for `ng-packagr`.