### PR TITLE
fix: disable rollups hoistTransitiveImports

### DIFF
--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -67,6 +67,7 @@ export async function rollupBundleFile(
     format: 'es',
     dir: opts.dir,
     inlineDynamicImports: false,
+    hoistTransitiveImports: false,
     chunkFileNames: opts.entryName + '-[name]-[hash].mjs',
     entryFileNames: opts.entryName + '.mjs',
     banner: '',


### PR DESCRIPTION
This fix disables the rollup option `hoistTransitiveImports` to address issues related to incorrect import behavior.

Closes https://github.com/angular/angular-cli/issues/28221
