### PR TITLE
build: allow TypeScript 5.6 and drop TypeScript 5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@angular/compiler-cli": "^19.0.0-next.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.4 <5.6"
+    "typescript": ">=5.5 <5.7"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
Prepares for the updated version range in Angular v19.
