### PR TITLE
build: adjust peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rollup": "^4.24.0"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^19.0.0-next.0",
+    "@angular/compiler-cli": "^19.0.0 || ^19.1.0-0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "tslib": "^2.3.0",
     "typescript": ">=5.5 <5.8"


### PR DESCRIPTION
Updates the `peerDependencies` to allow Angular `19.1.0-next`.
