### PR TITLE
perf: mitigate TypeScript 5.6+ performance regression

### DIFF
--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -147,9 +147,11 @@ export async function compileSourceFiles(
     }
 
     allDiagnostics.push(
-      ...builder.getDeclarationDiagnostics(sourceFile),
       ...builder.getSyntacticDiagnostics(sourceFile),
       ...builder.getSemanticDiagnostics(sourceFile),
+      // We use the `typeScriptProgram` instead of `builder` here as a
+      // performance workaround for: https://github.com/microsoft/TypeScript/issues/60970
+      ...typeScriptProgram.getDeclarationDiagnostics(sourceFile),
     );
 
     // Declaration files cannot have template diagnostics


### PR DESCRIPTION
Replaced `builder.getDeclarationDiagnostics` with `typeScriptProgram.getDeclarationDiagnostics` to avoid performance issues introduced in TypeScript 5.6+ reported in https://github.com/microsoft/TypeScript/issues/60970

Closes #2969