### PR TITLE
fix: disable TypeScript `removeComments` option

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -22,6 +22,10 @@ async function readDefaultTsConfig(fileName = defaultTsConfigPath): Promise<Pars
     outDir: '',
     declaration: true,
 
+    // Disable removing of comments as TS is quite aggressive with these and can
+    // remove important annotations, such as /* @__PURE__ */
+    removeComments: false,
+
     // ng compiler
     enableResourceInlining: true,
 


### PR DESCRIPTION
Disabling the `removeComments` option ensures important annotations like `/* @__PURE__ */` are preserved. TypeScript’s comment removal can be overly aggressive and strip out vital information, which is crucial for bundlers to eliminate dead code effectively. Non-essential comments will be handled by the bundler, so there’s no need to remove comments at the TypeScript level. This prevents unnecessary increases in final bundle size.

