### PR TITLE
feat: drop support for TypeScript older than 5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@angular/compiler-cli": "^20.0.0 || ^20.0.0-next.0",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.5 <5.9"
+    "typescript": ">=5.8 <5.9"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
Narrow down the versions of TypeScript to support.

BREAKING CHANGE: TypeScript versions less than 5.8 are no longer supported.
