### PR TITLE
fix: remove Node.js v18 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ commands:
           at: ~/repo
   setup_windows:
     steps:
-      - run: nvm install 18.19.1
-      - run: nvm use 18.19.1
+      - run: nvm install 20.11.1
+      - run: nvm use 20.11.1
       - run: npm install -g yarn@1.22.19
       - run: node --version
       - run: yarn --version
@@ -27,7 +27,7 @@ commands:
 executors:
   linux-executor:
     docker:
-      - image: cimg/node:18.19
+      - image: cimg/node:20.11
     working_directory: ~/repo
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scss"
   ],
   "engines": {
-    "node": "^18.19.1 || >=20.11.1"
+    "node": "^20.11.1 || >=22.0.0"
   },
   "author": "David Herges <david@spektrakel.de>",
   "license": "MIT",


### PR DESCRIPTION

Node.js v18 will reach its End-of-Life on 2025-04-30 and as a result will not be supported with the upcoming Angular v20.
Node.js Release Schedule: https://github.com/nodejs/release#release-schedule

BREAKING CHANGE: Node.js v18 is no longer supported 