### PR TITLE
fix: update minimum supported Node.js 22 version to 22.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "packageManager": "pnpm@9.15.6",
   "engines": {
-    "node": "^20.11.1 || >=22.0.0"
+    "node": "^20.11.1 || >=22.11.0"
   },
   "author": "David Herges <david@spektrakel.de>",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE: Node.js versions from 22.0 to 22.10 are no longer supported
