### PR TITLE
perf: prevent redundant entry-point builds in watch mode

### DIFF
--- a/src/lib/file-system/file-cache.ts
+++ b/src/lib/file-system/file-cache.ts
@@ -5,7 +5,6 @@ export interface CacheEntry {
   exists?: boolean;
   sourceFile?: ts.SourceFile;
   content?: string;
-  declarationFileName?: string;
 }
 
 export class FileCache {

--- a/src/lib/file-system/file-watcher.ts
+++ b/src/lib/file-system/file-watcher.ts
@@ -29,10 +29,6 @@ export function createFileWatch(
       /\.map$/,
       /.tsbuildinfo$/,
       file => {
-        if (file.endsWith('.d.ts')) {
-          return false;
-        }
-
         const normalizedPath = ensureUnixPath(file);
 
         return ignoredPaths.some(f => normalizedPath.startsWith(f));

--- a/src/lib/flatten/file-loader-plugin.ts
+++ b/src/lib/flatten/file-loader-plugin.ts
@@ -5,7 +5,7 @@ import { OutputFileCache } from '../ng-package/nodes';
 import * as log from '../utils/log';
 import { ensureUnixPath } from '../utils/path';
 
-const POTENTIAL_MATCHES = ['', '.mjs', '/index.mjs', '.d.ts', '/index.d.ts'];
+const POTENTIAL_MATCHES = ['', '.js', '/index.js', '.d.ts', '/index.d.ts'];
 /**
  * Loads a file and it's map.
  */

--- a/src/lib/graph/node.ts
+++ b/src/lib/graph/node.ts
@@ -1,6 +1,6 @@
-export type NodeState = '' | 'dirty' | 'in-progress' | 'pending' | 'done';
+export type NodeState = '' | 'error' | 'in-progress' | 'pending' | 'done';
 
-export const STATE_DIRTY: NodeState = 'dirty';
+export const STATE_ERROR: NodeState = 'error';
 export const STATE_IN_PROGRESS: NodeState = 'in-progress';
 export const STATE_PENDING: NodeState = 'pending';
 export const STATE_DONE: NodeState = 'done';

--- a/src/lib/graph/select.ts
+++ b/src/lib/graph/select.ts
@@ -1,4 +1,4 @@
-import { Node, STATE_DIRTY, STATE_DONE, STATE_IN_PROGRESS, STATE_PENDING } from './node';
+import { Node,  STATE_DONE, STATE_IN_PROGRESS, STATE_PENDING } from './node';
 
 export function and(...criteria: ((node: Node) => boolean)[]) {
   return (node: Node) => criteria.every(c => c(node));
@@ -26,10 +26,6 @@ export function isInProgress(node: Node): boolean {
 
 export function isPending(node: Node): boolean {
   return node.state === STATE_PENDING;
-}
-
-export function isDirty(node: Node): boolean {
-  return node.state === STATE_DIRTY;
 }
 
 export function isDone(node: Node): boolean {

--- a/src/lib/ng-package/entry-point/entry-point.ts
+++ b/src/lib/ng-package/entry-point/entry-point.ts
@@ -95,7 +95,7 @@ export class NgEntryPoint {
       declarations: pathJoinWithDest('tmp-typings', secondaryDir, `${flatModuleFile}.d.ts`),
       declarationsBundled: pathJoinWithDest(secondaryDir, 'index.d.ts'),
       declarationsDir: pathJoinWithDest(secondaryDir),
-      esm2022: pathJoinWithDest('tmp-esm2022', secondaryDir, `${flatModuleFile}.mjs`),
+      esm2022: pathJoinWithDest('tmp-esm2022', secondaryDir, `${flatModuleFile}.js`),
       fesm2022: pathJoinWithDest('fesm2022', `${flatModuleFile}.mjs`),
       fesm2022Dir: pathJoinWithDest('fesm2022'),
     };

--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -4,7 +4,7 @@ import ts from 'typescript';
 import { FileCache } from '../file-system/file-cache';
 import { ComplexPredicate } from '../graph/build-graph';
 import { Node } from '../graph/node';
-import { by, isDirty, isInProgress } from '../graph/select';
+import { by,  isInProgress, isPending } from '../graph/select';
 import { AngularDiagnosticsCache } from '../ngc/angular-diagnostics-cache';
 import { StylesheetProcessor } from '../styles/stylesheet-processor';
 import { DestinationFiles, NgEntryPoint } from './entry-point/entry-point';
@@ -35,8 +35,8 @@ export function isEntryPointInProgress(): ComplexPredicate<EntryPointNode> {
   return by(n => isEntryPoint(n) && isInProgress(n));
 }
 
-export function isEntryPointDirty(): ComplexPredicate<EntryPointNode> {
-  return by(n => isEntryPoint(n) && isDirty(n));
+export function isEntryPointPending(): ComplexPredicate<EntryPointNode> {
+  return by(n => isEntryPoint(n) && isPending(n));
 }
 
 export function fileUrl(path: string): string {

--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -99,18 +99,6 @@ export function cacheCompilerHost(
 
       assert(sourceFiles?.length === 1, 'Invalid TypeScript program emit for ' + fileName);
       const outputCache = entryPoint.cache.outputCache;
-
-      if (extension === '.ts') {
-        for (const source of sourceFiles) {
-          const cache = sourcesFileCache.getOrCreate(source.fileName);
-          if (!cache.declarationFileName) {
-            cache.declarationFileName = ensureUnixPath(fileName);
-          }
-        }
-      } else {
-        fileName = fileName.replace(/\.js(\.map)?$/, '.mjs$1');
-      }
-
       if (outputCache.get(fileName)?.content === data) {
         return;
       }


### PR DESCRIPTION
Before this commit, emitting a DTS file would trigger a rebuild of dependent entry points. With this update, a rebuild occurs only if the contents of the DTS file change.

Closes: #2936
