### PR TITLE
fix: disable emitting empty chunk warning

### DIFF
--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -49,6 +49,7 @@ export async function rollupBundleFile(
         case 'CIRCULAR_DEPENDENCY':
         case 'UNUSED_EXTERNAL_IMPORT':
         case 'THIS_IS_UNDEFINED':
+        case 'EMPTY_BUNDLE':
           break;
 
         default:


### PR DESCRIPTION
Example `WARNING: Generated an empty chunk: "foo.d".` is not not actionable.
