### PR TITLE
fix: disable TypeScript `composite` option with Angular compiler

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -14,6 +14,8 @@ async function readDefaultTsConfig(fileName = defaultTsConfigPath): Promise<Pars
   const extraOptions: CompilerOptions = {
     target: ts.ScriptTarget.ES2022,
 
+    composite: false,
+
     // sourcemaps
     sourceMap: true,
     inlineSources: true,


### PR DESCRIPTION
The Angular compiler does not directly support the `composite` option within a referenced `tsconfig` file. If this option is enabled, the Angular compiler will crash due to the Angular compiler not leveraging the TypeScript BuilderProgram infrastructure. Since the Angular compiler is not aware of composite projects nor project references, the `composite` option is disabled when options are passed to the Angular compiler. This has no effect on non- Angular related usages of the `tsconfig`.
