### PR TITLE
feat: expand browser support to widely available Baseline

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,8 @@
+# From "widely available" Baseline for 2025-03-31.
+Chrome >= 107
+ChromeAndroid >= 107
+Edge >= 107
+Firefox >= 104
+FirefoxAndroid >= 104
+Safari >= 16
+iOS >= 16

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -2,6 +2,7 @@ const { readFileSync, copyFileSync, writeFileSync, constants, mkdirSync } = requ
 
 copyFileSync('LICENSE', 'dist/LICENSE', constants.COPYFILE_FICLONE);
 copyFileSync('README.md', 'dist/README.md', constants.COPYFILE_FICLONE);
+copyFileSync('.browserslistrc', 'dist/.browserslistrc', constants.COPYFILE_FICLONE);
 copyFileSync('src/ng-package.schema.json', 'dist/ng-package.schema.json', constants.COPYFILE_FICLONE);
 copyFileSync('src/ng-entrypoint.schema.json', 'dist/ng-entrypoint.schema.json', constants.COPYFILE_FICLONE);
 

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -21,15 +21,10 @@ export class StylesheetProcessor extends ComponentStylesheetBundler {
     // By default, browserslist defaults are too inclusive
     // https://github.com/browserslist/browserslist/blob/83764ea81ffaa39111c204b02c371afa44a4ff07/index.js#L516-L522
     // We change the default query to browsers that Angular support.
-    // https://angular.io/guide/browser-support
-    (browserslist.defaults as string[]) = [
-      'last 2 Chrome versions',
-      'last 1 Firefox version',
-      'last 2 Edge major versions',
-      'last 2 Safari major versions',
-      'last 2 iOS major versions',
-      'Firefox ESR',
-    ];
+    // https://angular.dev/reference/versions#browser-support
+    (browserslist.defaults as string[]) = browserslist(undefined, {
+      path: require.resolve('../../../.browserslistrc'),
+    });
 
     const browserslistData = browserslist(undefined, { path: basePath });
     const searchDirs = generateSearchDirectories([projectBasePath]);


### PR DESCRIPTION
This changes the default `.browserslistrc` file to one generated from a Baseline "widely available" date using `bl2bl`, codifying the policy change from https://github.com/angular/angular/pull/60754 into `ng-packagr`.

This effectively pins the `.browserslistrc` file to a hard-coded configuration from a specific Baseline date, preventing it from automatically updating based on `caniuse-lite` versions managed in user workspaces, which should make Angular's tooling much more stable. Prior to this, expressions like "last 2 Chrome versions" were relative to the installed `caniuse-lite` version and could update at any time. By pinning `.browserslistrc`, we're ensuring that supported browsers only change during Angular major version updates, not arbitrary `caniuse-lite` updates.

The [Angular CLI implementation](https://github.com/angular/angular-cli/pull/30036) hard-codes the Baseline date and the uses `baseline-browser-mapping` to generate the `browserslist` configuration. We could copy that process here, however I didn't want to duplicate all the code and instead just hard-coded the `browserslist` configuration itself. As part of the release process, we can bump the date in Angular CLI, build the configuration, and then copy it over to `ng-packagr`. We already need to copy the config out for the docs anyways, so this doesn't significantly increase the toil involved.

Let me know if you'd rather I explore actually generating this information from a hard-coded date rather than inlining the `browserslist` config entirely. Also let me know if there's any particular ways I should be testing this.

Blocked on: https://github.com/angular/angular/pull/60754