### PR TITLE
fix: drop support for TypeScript 5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@angular/compiler-cli": "^21.0.0-next",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.8 <6.0"
+    "typescript": ">=5.9 <6.0"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
Now that https://github.com/angular/angular/pull/63589 has landed, we can drop support for TypeScript 5.8.

BREAKING CHANGE: TypeScript versions older than 5.9 are no longer supported.
