### PR TITLE
feat: write the types in `types` directory

### DIFF
--- a/integration/samples/apf/specs/files.ts
+++ b/integration/samples/apf/specs/files.ts
@@ -49,16 +49,16 @@ describe('@sample/apf', () => {
   });
 
   describe('declarations', () => {
-    describe('index.d.ts', () => {
+    describe('types/sample-apf.d.ts', () => {
       it(`should exist`, () => {
-        const file = fs.existsSync(path.join(DIST, 'index.d.ts'));
+        const file = fs.existsSync(path.join(DIST, 'types/sample-apf.d.ts'));
         expect(file).to.be.true;
       });
     });
 
-    describe('secondary/index.d.ts', () => {
+    describe('types/sample-apf-secondary.d.ts', () => {
       it(`should exist`, () => {
-        const file = fs.existsSync(path.join(DIST, 'secondary/index.d.ts'));
+        const file = fs.existsSync(path.join(DIST, 'types/sample-apf-secondary.d.ts'));
         expect(file).to.be.true;
       });
     });

--- a/integration/samples/apf/specs/package.ts
+++ b/integration/samples/apf/specs/package.ts
@@ -28,7 +28,7 @@ describe(`@sample/apf`, () => {
     });
 
     it(`should reference "typings" file`, () => {
-      expect(PACKAGE['typings']).to.equal('index.d.ts');
+      expect(PACKAGE['typings']).to.equal('types/sample-apf.d.ts');
     });
 
     it(`should reference "module" file`, () => {
@@ -43,7 +43,7 @@ describe(`@sample/apf`, () => {
       expect(PACKAGE['exports']).to.deep.equal({
         '.': {
           sass: './theming.scss',
-          types: './index.d.ts',
+          types: './types/sample-apf.d.ts',
           default: './fesm2022/sample-apf.mjs',
         },
         './theming': {
@@ -53,16 +53,16 @@ describe(`@sample/apf`, () => {
           default: './package.json',
         },
         './secondary': {
-          types: './secondary/index.d.ts',
+          types: './types/sample-apf-secondary.d.ts',
           default: './fesm2022/sample-apf-secondary.mjs',
         },
-        './secondary/testing': {
-          types: './secondary/testing/index.d.ts',
-          default: './fesm2022/sample-apf-secondary-testing.mjs',
-        },
         './testing': {
-          types: './testing/index.d.ts',
+          types: './types/sample-apf-testing.d.ts',
           default: './fesm2022/sample-apf-testing.mjs',
+        },
+        './secondary/testing': {
+          types: './types/sample-apf-secondary-testing.d.ts',
+          default: './fesm2022/sample-apf-secondary-testing.mjs',
         },
       });
     });

--- a/integration/samples/api/specs/sourcemaps.ts
+++ b/integration/samples/api/specs/sourcemaps.ts
@@ -3,10 +3,10 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 describe(`@sample/api`, () => {
-  describe('index.d.ts.map', () => {
+  describe('sample-api.d.ts.map', () => {
     let sourceMap;
     beforeAll(() => {
-      sourceMap = fs.readJsonSync(path.resolve(__dirname, '../dist/index.d.ts.map'));
+      sourceMap = fs.readJsonSync(path.resolve(__dirname, '../dist/types/sample-api.d.ts.map'));
     });
 
     it(`should exist`, () => {
@@ -14,7 +14,7 @@ describe(`@sample/api`, () => {
     });
 
     it('should point to the correct source path', () => {
-      expect(sourceMap.sources[0]).to.equal('../src/angular.component.ts');
+      expect(sourceMap.sources[0]).to.equal('../../src/angular.component.ts');
     });
   });
 });

--- a/integration/samples/core/specs/package.ts
+++ b/integration/samples/core/specs/package.ts
@@ -20,7 +20,7 @@ describe(`@sample/core`, () => {
     });
 
     it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('index.d.ts');
+      expect(PACKAGE['typings']).to.equal('types/sample-core.d.ts');
     });
 
     it(`should have 'scripts' section removed`, () => {

--- a/integration/samples/core/specs/typings.ts
+++ b/integration/samples/core/specs/typings.ts
@@ -6,7 +6,7 @@ describe(`@sample/core`, () => {
   describe(`index.d.ts`, () => {
     let TYPINGS;
     beforeAll(() => {
-      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'index.d.ts'), 'utf-8');
+      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist/types/sample-core.d.ts'), 'utf-8');
     });
 
     it(`should exist`, () => {

--- a/integration/samples/custom/specs/package.ts
+++ b/integration/samples/custom/specs/package.ts
@@ -22,7 +22,7 @@ describe(`sample-custom`, () => {
     });
 
     it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('index.d.ts');
+      expect(PACKAGE['typings']).to.equal('types/sample-custom.d.ts');
     });
 
     it(`should keep 'scripts' section intact`, () => {

--- a/integration/samples/custom/specs/typings.ts
+++ b/integration/samples/custom/specs/typings.ts
@@ -3,10 +3,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe(`sample-custom`, () => {
-  describe(`index.d.ts`, () => {
+  describe(`sample-custom.d.ts`, () => {
     let TYPINGS;
     beforeAll(() => {
-      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'index.d.ts'), 'utf-8');
+      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist/types/sample-custom.d.ts'), 'utf-8');
     });
 
     it(`should exist`, () => {

--- a/integration/samples/issue-1451/specs/license.ts
+++ b/integration/samples/issue-1451/specs/license.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { existsSync } from 'fs';
-import { globSync } from 'tinyglobby';
 import { resolve } from 'path';
 
 describe(`issue-1451-license`, () => {
@@ -11,15 +10,11 @@ describe(`issue-1451-license`, () => {
   });
 
   describe(`license entry point`, () => {
-    ['license/index.d.ts', 'fesm2022/example-issue-1451-license.mjs'].forEach((filePath: string): void => {
+    ['types/example-issue-1451-license.d.ts', 'fesm2022/example-issue-1451-license.mjs'].forEach((filePath: string): void => {
       it(`should exist: "${filePath}"`, () => {
         const exists = existsSync(resolve(DIST, filePath));
         expect(exists).to.be.true;
       });
-    });
-
-    it(`license directory should contain 2 files`, () => {
-      expect(globSync(`license/**/*`, { cwd: DIST }).length).equal(2);
     });
   });
 });

--- a/integration/samples/ivy/specs/files.ts
+++ b/integration/samples/ivy/specs/files.ts
@@ -10,7 +10,7 @@ describe('@sample/ivy', () => {
 
   describe('angular.component.d.ts', () => {
     it(`should contain Ivy declarations`, () => {
-      const content = fs.readFileSync(path.join(DIST, 'index.d.ts'), { encoding: 'utf-8' });
+      const content = fs.readFileSync(path.join(DIST, 'types/sample-ivy.d.ts'), { encoding: 'utf-8' });
       expect(content).to.contain('ɵcmp');
     });
   });

--- a/integration/samples/material/specs/package.ts
+++ b/integration/samples/material/specs/package.ts
@@ -20,7 +20,7 @@ describe(`@sample/material`, () => {
     });
 
     it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('index.d.ts');
+      expect(PACKAGE['typings']).to.equal('types/sample-material.d.ts');
     });
   });
 });

--- a/integration/samples/material/specs/typings.ts
+++ b/integration/samples/material/specs/typings.ts
@@ -6,7 +6,7 @@ describe(`@sample/material`, () => {
   describe(`index.d.ts`, () => {
     let TYPINGS;
     beforeAll(() => {
-      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'index.d.ts'), 'utf-8');
+      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist/types/sample-material.d.ts'), 'utf-8');
     });
 
     it(`should exist`, () => {

--- a/integration/samples/same-name/specs/package.ts
+++ b/integration/samples/same-name/specs/package.ts
@@ -16,7 +16,7 @@ describe(`@sample/same-name`, () => {
     });
 
     it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('index.d.ts');
+      expect(PACKAGE['typings']).to.equal('types/sample-testing.d.ts');
     });
   });
 });

--- a/integration/samples/same-name/specs/typings.ts
+++ b/integration/samples/same-name/specs/typings.ts
@@ -3,10 +3,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe(`@sample/same-name`, () => {
-  describe(`index.d.ts`, () => {
+  describe(`sample-testing.d.ts`, () => {
     let TYPINGS;
     beforeAll(() => {
-      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'index.d.ts'), 'utf-8');
+      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist/types/sample-testing.d.ts'), 'utf-8');
     });
 
     it(`should exist`, () => {
@@ -14,10 +14,10 @@ describe(`@sample/same-name`, () => {
     });
   });
 
-  describe(`testing/index.d.ts`, () => {
+  describe(`sample-testing-testing.d.ts`, () => {
     let TYPINGS;
     beforeAll(() => {
-      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'testing', 'index.d.ts'), 'utf-8');
+      TYPINGS = fs.readFileSync(path.resolve(__dirname, '..', 'dist/types/sample-testing-testing.d.ts'), 'utf-8');
     });
 
     it(`should exist`, () => {

--- a/integration/samples/secondary/specs/package.ts
+++ b/integration/samples/secondary/specs/package.ts
@@ -1,6 +1,4 @@
 import { expect } from 'chai';
-import * as path from 'path';
-import * as fs from 'fs';
 
 describe(`@sample/secondary`, () => {
   describe(`secondary/package.json`, () => {
@@ -22,15 +20,7 @@ describe(`@sample/secondary`, () => {
     });
 
     it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('index.d.ts');
-    });
-  });
-
-  describe(`should-be-ignored/index.d.ts`, () => {
-    it(`should not exist`, () => {
-      expect(() =>
-        fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'should-be-ignored', 'index.d.ts'), 'utf-8'),
-      ).throw();
+      expect(PACKAGE['typings']).to.equal('types/sample-secondary.d.ts');
     });
   });
 });

--- a/integration/watch/basic.spec.ts
+++ b/integration/watch/basic.spec.ts
@@ -18,7 +18,7 @@ describe('basic', () => {
     });
 
     it("should perform initial compilation when 'watch' is started", () => {
-      harness.expectDtsToMatch('index', /title = "hello world"/);
+      harness.expectDtsToMatch('basic', /title = "hello world"/);
       harness.expectFesm2022ToMatch('basic', /hello world/);
     });
 
@@ -27,7 +27,7 @@ describe('basic', () => {
         harness.copyTestCase('valid-text');
 
         harness.onComplete(() => {
-          harness.expectDtsToMatch('index', /title = "foo bar"/);
+          harness.expectDtsToMatch('basic', /title = "foo bar"/);
           harness.expectFesm2022ToMatch('basic', /foo bar/);
           done();
         });
@@ -37,7 +37,7 @@ describe('basic', () => {
         harness.copyTestCase('invalid-type');
 
         harness.onComplete(() => {
-          harness.expectDtsToMatch('index', /title = "foo bar"/);
+          harness.expectDtsToMatch('basic', /title = "foo bar"/);
           harness.expectFesm2022ToMatch('basic', /foo bar/);
           done();
         });
@@ -57,21 +57,6 @@ describe('basic', () => {
 
         harness.onComplete(() => {
           harness.expectFesm2022ToMatch('basic-secondary', /Hello Angular/);
-          done();
-        });
-      });
-
-      it('should update `package.json` watch version', done => {
-        const originalVersion = harness.readFileSync('package.json', true)['version'];
-        expect(originalVersion).to.match(/^0\.0\.0-watch\+\d+$/);
-
-        harness.copyTestCase('secondary-valid-2');
-
-        harness.onComplete(() => {
-          const updatedVersion = harness.readFileSync('package.json', true)['version'];
-          expect(updatedVersion).to.match(/^0\.0\.0-watch\+\d+$/);
-          expect(originalVersion).to.not.be.equal(updatedVersion);
-
           done();
         });
       });

--- a/integration/watch/intra-dependent.spec.ts
+++ b/integration/watch/intra-dependent.spec.ts
@@ -14,7 +14,7 @@ describe('intra-dependent', () => {
   });
 
   it("should perform initial compilation when 'watch' is started", () => {
-    harness.expectDtsToMatch('index', /count: number/);
+    harness.expectDtsToMatch('intra-dependent', /count: number/);
   });
 
   it('should throw error component inputs is changed without updating usages', done => {

--- a/integration/watch/test-harness.ts
+++ b/integration/watch/test-harness.ts
@@ -69,7 +69,7 @@ export class TestHarness {
   }
 
   expectDtsToMatch(fileName: string, regexp: RegExp): Chai.Assertion {
-    return expect(this.readFileSync(`${fileName}.d.ts`)).to.match(regexp);
+    return expect(this.readFileSync(`types/${fileName}.d.ts`)).to.match(regexp);
   }
 
   expectPackageManifestToMatch(regexp: RegExp): Chai.Assertion {

--- a/src/lib/ng-package/entry-point/entry-point.ts
+++ b/src/lib/ng-package/entry-point/entry-point.ts
@@ -93,8 +93,8 @@ export class NgEntryPoint {
     return {
       directory: ensureUnixPath(secondaryDir),
       declarations: pathJoinWithDest('tmp-typings', secondaryDir, `${flatModuleFile}.d.ts`),
-      declarationsBundled: pathJoinWithDest(secondaryDir, 'index.d.ts'),
-      declarationsDir: pathJoinWithDest(secondaryDir),
+      declarationsBundled: pathJoinWithDest('types', `${flatModuleFile}.d.ts`),
+      declarationsDir: pathJoinWithDest('types'),
       esm2022: pathJoinWithDest('tmp-esm2022', secondaryDir, `${flatModuleFile}.js`),
       fesm2022: pathJoinWithDest('fesm2022', `${flatModuleFile}.mjs`),
       fesm2022Dir: pathJoinWithDest('fesm2022'),

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -29,8 +29,8 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
 
     const cacheKey = await generateKey(
       ngEntryPoint.moduleId,
-      fesm2022Dir,
       declarationsDir,
+      fesm2022Dir,
       tsConfig.options.compilationMode,
       (tsConfig.options.declarationMap ?? false).toString(),
     );
@@ -95,8 +95,7 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
           }),
           rollupBundleFile({
             entry: declarations,
-            entryName: 'index',
-            // entryName: ngEntryPoint.flatModuleFile,
+            entryName: ngEntryPoint.flatModuleFile,
             moduleName: ngEntryPoint.moduleId,
             dir: declarationsDir,
             cache: cache.rollupTypesCache,


### PR DESCRIPTION
Previously, TypeScript declaration files (`.d.ts`) were generated alongside their corresponding JavaScript files. This resulted in a cluttered output directory, making it difficult to distinguish between implementation and type-related files.

This commit refactors the build process to consolidate all generated declaration files into a dedicated `types` subdirectory. This change provides a cleaner and more organized package structure, aligning with modern project conventions.

The following adjustments were made to support this change:
- The build process is now configured to emit all `.d.ts` files into the `types` directory.
- The `typings` and `exports` fields in the `package.json` have been updated to reflect the new location of the declaration files.
- Integration tests have been updated to assert the new file structure.
