### PR TITLE
perf: reduce memory usage for multiple entry-points (non-watch)

### DIFF
--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -4,7 +4,7 @@ import ts from 'typescript';
 import { FileCache } from '../file-system/file-cache';
 import { ComplexPredicate } from '../graph/build-graph';
 import { Node } from '../graph/node';
-import { by,  isInProgress, isPending } from '../graph/select';
+import { by, isInProgress, isPending } from '../graph/select';
 import { AngularDiagnosticsCache } from '../ngc/angular-diagnostics-cache';
 import { StylesheetProcessor } from '../styles/stylesheet-processor';
 import { DestinationFiles, NgEntryPoint } from './entry-point/entry-point';
@@ -58,8 +58,8 @@ export class EntryPointNode extends Node {
 
   constructor(
     public readonly url: string,
-    sourcesFileCache: FileCache,
-    moduleResolutionCache: ts.ModuleResolutionCache,
+     sourcesFileCache: FileCache,
+     moduleResolutionCache: ts.ModuleResolutionCache,
   ) {
     super(url);
 
@@ -91,6 +91,11 @@ export class EntryPointNode extends Node {
     entryPoint: NgEntryPoint;
     tsConfig?: ParsedConfiguration;
   };
+
+  dipose(): void {
+    void this.cache.stylesheetProcessor?.destroy();
+    this.cache = undefined;
+  }
 }
 
 export class PackageNode extends Node {


### PR DESCRIPTION
reduce memory usage when building projects with multiple entry-points in non-watch mode.

Closes #3168