### PR TITLE
fix: ensure deterministic ordering of 'exports' field

### DIFF
--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -356,7 +356,8 @@ function generatePackageExports(
 
   insertMappingOrError('./package.json', { default: './package.json' });
 
-  for (const entryPoint of entryPoints) {
+  const entryPointsSorted = entryPoints.sort((a, b) => a.url.localeCompare(b.url));
+  for (const entryPoint of entryPointsSorted) {
     const { destinationFiles, isSecondaryEntryPoint } = entryPoint.data.entryPoint;
     const subpath = isSecondaryEntryPoint ? `./${destinationFiles.directory}` : '.';
 


### PR DESCRIPTION
The 'exports' field in the generated 'package.json' had non-deterministic ordering, leading to inconsistent package integrity checksums between builds. This caused CI/CD failures and non-reproducible builds.

This change sorts the keys of the 'exports' field alphabetically to ensure a consistent and deterministic output, resolving integrity issues and improving build reproducibility.

Closes #3175