### PR TITLE
fix: set filename for declarations bundle on rollup

### DIFF
--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -7,22 +7,31 @@ import { readCacheEntry, saveCacheEntry } from '../utils/cache';
 import * as log from '../utils/log';
 import { fileLoaderPlugin } from './file-loader-plugin';
 
-/**
- * Options used in `ng-packagr` for writing flat bundle files.
- *
- * These options are passed through to rollup.
- */
-export interface RollupOptions {
+interface RollupCommonOptions {
   moduleName: string;
   entry: string;
   entryName: string;
-  dir: string;
   cache?: RollupCache;
   cacheDirectory?: string | false;
   fileCache: OutputFileCache;
   cacheKey: string;
   sourcemap: boolean;
 }
+
+interface RollupOptionsDir extends RollupCommonOptions {
+  dir: string;
+}
+
+interface RollupOptionsFile extends RollupCommonOptions {
+  file: string;
+}
+
+/**
+ * Options used in `ng-packagr` for writing flat bundle files.
+ *
+ * These options are passed through to rollup.
+ */
+export type RollupOptions = RollupOptionsDir | RollupOptionsFile;
 
 let rollup: typeof import('rollup') | undefined;
 
@@ -76,7 +85,7 @@ export async function rollupBundleFile(
   const output = await bundle.write({
     name: opts.moduleName,
     format: 'es',
-    dir: opts.dir,
+    ...('dir' in opts ? { dir: opts.dir } : { file: opts.file }),
     inlineDynamicImports: false,
     hoistTransitiveImports: false,
     chunkFileNames: `${opts.entryName}-[name]-[hash]${outExtension}`,

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -97,7 +97,7 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
             entry: declarations,
             entryName: ngEntryPoint.flatModuleFile,
             moduleName: ngEntryPoint.moduleId,
-            dir: declarationsDir,
+            file: join(declarationsDir, `${ngEntryPoint.flatModuleFile}.d.ts`),
             cache: cache.rollupTypesCache,
             cacheDirectory,
             fileCache: cache.outputCache,


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

Sorry, no test yet. I wanted to quickly propose the approach and will add a test when I find the time.

## Description

After 7a5e8fbd51010db91d0a74bf6efb6c0eb6732a00 .d.ts bundles containing `declare module` statements with relative paths are no longer valid. This is because the change to rollup-plugin-dts that fixed ng-packagr/ng-packagr#3085 expects to find the target file name in options.file and otherwise falls back to index.d.ts.

This commit makes sure the full and proper file name is set in the options for rollup.

Fixes #3190

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
