### PR TITLE
fix: allow TypeScript 6 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@angular/compiler-cli": "^21.2.0-next",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.9 <6.0"
+    "typescript": ">=5.9 <6.1"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
Expands the peer dependency range to allow TypeScript 6.
