### PR TITLE
fix: ensure dts sourcemaps point to original ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ora": "^9.0.0",
     "piscina": "^5.0.0",
     "postcss": "^8.4.47",
-    "rollup-plugin-dts": "^6.2.0",
+    "rollup-plugin-dts": "^6.4.0",
     "rxjs": "^7.8.1",
     "sass": "^1.81.0",
     "tinyglobby": "^0.2.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^8.4.47
         version: 8.5.6
       rollup-plugin-dts:
-        specifier: ^6.2.0
-        version: 6.3.0(rollup@4.59.0)(typescript@5.9.3)
+        specifier: ^6.4.0
+        version: 6.4.0(rollup@4.59.0)(typescript@5.9.3)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -3954,12 +3954,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup-plugin-dts@6.3.0:
-    resolution: {integrity: sha512-d0UrqxYd8KyZ6i3M2Nx7WOMy708qsV/7fTHMHxCMCBOAe3V/U7OMPu5GkX8hC+cmkHhzGnfeYongl1IgiooddA==}
+  rollup-plugin-dts@6.4.0:
+    resolution: {integrity: sha512-2i00A5UoPCoDecLEs13Eu105QegSGfrbp1sDeUj/54LKGmv6XFHDxWKC6Wsb4BobGUWYVCWWjmjAc8bXXbXH/Q==}
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^4.5 || ^5.0
+      typescript: ^4.5 || ^5.0 || ^6.0
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -8442,8 +8442,11 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.6
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.6
 
-  rollup-plugin-dts@6.3.0(rollup@4.59.0)(typescript@5.9.3):
+  rollup-plugin-dts@6.4.0(rollup@4.59.0)(typescript@5.9.3):
     dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      convert-source-map: 2.0.0
       magic-string: 0.30.21
       rollup: 4.59.0
       typescript: 5.9.3

--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -41,7 +41,7 @@ export async function rollupBundleFile(
 
   if (dtsMode) {
     outExtension = '.d.ts';
-    plugins = [fileLoaderPlugin(opts.fileCache, ['.d.ts', '/index.d.ts']), dts()];
+    plugins = [fileLoaderPlugin(opts.fileCache, ['.d.ts', '/index.d.ts']), dts({ sourcemap: opts.sourcemap })];
   } else {
     outExtension = '.mjs';
     plugins = [fileLoaderPlugin(opts.fileCache, ['.js', '/index.js']), rollupJson()];

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -102,7 +102,7 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
             cacheDirectory,
             fileCache: cache.outputCache,
             cacheKey,
-            sourcemap: tsConfig.options.declarationMap || false,
+            sourcemap: tsConfig.options.declarationMap ?? false,
           }),
         ]);
 


### PR DESCRIPTION
Updated rollup-plugin-dts to v6.4.0 and ensured the sourcemap option is explicitly passed to the plugin.

This addresses a regression introduced in rollup-plugin-dts v6.4.0 where declaration maps were not correctly processed unless the plugin-level sourcemap option was enabled. Without this, bundled .d.ts files would only map back to intermediate .d.ts files rather than the original .ts source files.

Reference: https://github.com/Swatinem/rollup-plugin-dts/commit/8014766f7c6ca8f033028ef0ea2c558c4e49fe71
