### PR TITLE
fix: default generated package.json type to module

### DIFF
--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -196,6 +196,7 @@ async function writePackageJson(
 
   // set additional properties
   const packageJson = { ...entryPoint.packageJson, ...additionalProperties };
+  packageJson.type ??= 'module';
 
   // read tslib version from `@angular/compiler` so that our tslib
   // version at least matches that of angular if we use require('tslib').version


### PR DESCRIPTION
When `type` is not specified in the source `package.json` or additional properties, default it to `'module'`. This ensures modern tools and environments (such as Node.js) correctly treat the generated files in the package as ES Modules by default.
