### PR TITLE
fix: use correct this context in cacheCompilerHost method delegates

### DIFF
--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -54,7 +54,7 @@ export function cacheCompilerHost(
     fileExists: (fileName: string) => {
       const cache = sourcesFileCache.getOrCreate(fileName);
       if (cache.exists === undefined) {
-        cache.exists = compilerHost.fileExists.call(this, fileName);
+        cache.exists = compilerHost.fileExists.call(compilerHost, fileName);
       }
 
       return cache.exists;
@@ -66,7 +66,7 @@ export function cacheCompilerHost(
 
       if (shouldCreateNewSourceFile || !cache.sourceFile) {
         cache.sourceFile = compilerHost.getSourceFile.call(
-          this,
+          compilerHost,
           fileName,
           languageVersion,
           onError,
@@ -92,7 +92,7 @@ export function cacheCompilerHost(
       const extension = path.extname(fileName);
       if (!sourceFiles?.length && extension === '.tsbuildinfo') {
         // Save builder info contents to specified location
-        compilerHost.writeFile.call(this, fileName, data, writeByteOrderMark, onError, sourceFiles);
+        compilerHost.writeFile.call(compilerHost, fileName, data, writeByteOrderMark, onError, sourceFiles);
 
         return;
       }
@@ -113,7 +113,7 @@ export function cacheCompilerHost(
       addDependee(fileName);
       const cache = sourcesFileCache.getOrCreate(fileName);
       if (cache.content === undefined) {
-        cache.content = compilerHost.readFile.call(this, fileName);
+        cache.content = compilerHost.readFile.call(compilerHost, fileName);
       }
 
       return cache.content;
@@ -128,7 +128,7 @@ export function cacheCompilerHost(
       return resourcePath;
     },
 
-    readResource: async (fileName: string) => {
+    readResource: async (fileName: string): Promise<string> => {
       addDependee(fileName);
 
       const cache = sourcesFileCache.getOrCreate(fileName);
@@ -139,9 +139,12 @@ export function cacheCompilerHost(
 
         if (/(?:html?|svg)$/.test(path.extname(fileName))) {
           // template
-          cache.content = compilerHost.readFile.call(this, fileName);
+          cache.content = compilerHost.readFile.call(compilerHost, fileName);
         } else {
           // stylesheet
+          if (!stylesheetProcessor) {
+            throw new Error('stylesheetProcessor is not available for processing stylesheets');
+          }
           const {
             referencedFiles,
             contents,
@@ -149,7 +152,7 @@ export function cacheCompilerHost(
             warnings: esBuildWarnings,
           } = await stylesheetProcessor.bundleFile(fileName);
           const node = getNode(fileName);
-          const depNodes = [...referencedFiles].map(getNode).filter(n => n !== node);
+          const depNodes = [...(referencedFiles ?? [])].map(getNode).filter(n => n !== node);
           node.dependsOn(depNodes);
 
           for (const n of node.dependees) {
@@ -158,11 +161,11 @@ export function cacheCompilerHost(
             }
           }
 
-          if (esBuildWarnings?.length > 0) {
+          if (esBuildWarnings && esBuildWarnings.length > 0) {
             (await formatMessages(esBuildWarnings, { kind: 'warning' })).forEach(msg => warn(msg));
           }
 
-          if (esbuildErrors?.length > 0) {
+          if (esbuildErrors && esbuildErrors.length > 0) {
             (await formatMessages(esbuildErrors, { kind: 'error' })).forEach(msg => error(msg));
 
             throw new Error(`An error has occuried while processing ${fileName}.`);
@@ -174,7 +177,7 @@ export function cacheCompilerHost(
         cache.exists = true;
       }
 
-      return cache.content;
+      return cache.content ?? '';
     },
     transformResource: async (data, context) => {
       const { containingFile, resourceFile, type } = context;
@@ -184,6 +187,9 @@ export function cacheCompilerHost(
       }
 
       if (inlineStyleLanguage) {
+        if (!stylesheetProcessor) {
+          throw new Error('stylesheetProcessor is not available for processing inline styles');
+        }
         const {
           contents,
           referencedFiles,
@@ -196,13 +202,13 @@ export function cacheCompilerHost(
         );
 
         const node = getNode(containingFile);
-        node.dependsOn([...referencedFiles].map(getNode));
+        node.dependsOn([...(referencedFiles ?? [])].map(getNode));
 
-        if (esBuildWarnings?.length > 0) {
+        if (esBuildWarnings?.length) {
           (await formatMessages(esBuildWarnings, { kind: 'warning' })).forEach(msg => warn(msg));
         }
 
-        if (esbuildErrors?.length > 0) {
+        if (esbuildErrors?.length) {
           (await formatMessages(esbuildErrors, { kind: 'error' })).forEach(msg => error(msg));
 
           throw new Error(`An error has occuried while processing ${containingFile}.`);

--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -54,7 +54,7 @@ export function cacheCompilerHost(
     fileExists: (fileName: string) => {
       const cache = sourcesFileCache.getOrCreate(fileName);
       if (cache.exists === undefined) {
-        cache.exists = compilerHost.fileExists.call(compilerHost, fileName);
+        cache.exists = compilerHost.fileExists(fileName);
       }
 
       return cache.exists;
@@ -65,14 +65,7 @@ export function cacheCompilerHost(
       const cache = sourcesFileCache.getOrCreate(fileName);
 
       if (shouldCreateNewSourceFile || !cache.sourceFile) {
-        cache.sourceFile = compilerHost.getSourceFile.call(
-          compilerHost,
-          fileName,
-          languageVersion,
-          onError,
-          true,
-          ...parameters,
-        );
+        cache.sourceFile = compilerHost.getSourceFile(fileName, languageVersion, onError, true, ...parameters);
       }
 
       return cache.sourceFile;
@@ -92,7 +85,7 @@ export function cacheCompilerHost(
       const extension = path.extname(fileName);
       if (!sourceFiles?.length && extension === '.tsbuildinfo') {
         // Save builder info contents to specified location
-        compilerHost.writeFile.call(compilerHost, fileName, data, writeByteOrderMark, onError, sourceFiles);
+        compilerHost.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
 
         return;
       }
@@ -113,7 +106,7 @@ export function cacheCompilerHost(
       addDependee(fileName);
       const cache = sourcesFileCache.getOrCreate(fileName);
       if (cache.content === undefined) {
-        cache.content = compilerHost.readFile.call(compilerHost, fileName);
+        cache.content = compilerHost.readFile(fileName);
       }
 
       return cache.content;
@@ -139,7 +132,7 @@ export function cacheCompilerHost(
 
         if (/(?:html?|svg)$/.test(path.extname(fileName))) {
           // template
-          cache.content = compilerHost.readFile.call(compilerHost, fileName);
+          cache.content = compilerHost.readFile(fileName);
         } else {
           // stylesheet
           if (!stylesheetProcessor) {
@@ -161,11 +154,11 @@ export function cacheCompilerHost(
             }
           }
 
-          if (esBuildWarnings && esBuildWarnings.length > 0) {
+          if (esBuildWarnings?.length) {
             (await formatMessages(esBuildWarnings, { kind: 'warning' })).forEach(msg => warn(msg));
           }
 
-          if (esbuildErrors && esbuildErrors.length > 0) {
+          if (esbuildErrors?.length) {
             (await formatMessages(esbuildErrors, { kind: 'error' })).forEach(msg => error(msg));
 
             throw new Error(`An error has occuried while processing ${fileName}.`);
@@ -187,9 +180,6 @@ export function cacheCompilerHost(
       }
 
       if (inlineStyleLanguage) {
-        if (!stylesheetProcessor) {
-          throw new Error('stylesheetProcessor is not available for processing inline styles');
-        }
         const {
           contents,
           referencedFiles,
@@ -202,7 +192,7 @@ export function cacheCompilerHost(
         );
 
         const node = getNode(containingFile);
-        node.dependsOn([...(referencedFiles ?? [])].map(getNode));
+        node.dependsOn([...referencedFiles].map(getNode));
 
         if (esBuildWarnings?.length) {
           (await formatMessages(esBuildWarnings, { kind: 'warning' })).forEach(msg => warn(msg));


### PR DESCRIPTION
Part of https://github.com/ng-packagr/ng-packagr/pull/3252

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

`cacheCompilerHost` wraps several `compilerHost` methods (`fileExists`, `getSourceFile`, `writeFile`, `readFile`, `readResource`) inside arrow functions, then delegates via `.call(this, ...)`. Because these are arrow functions, `this` resolves to the enclosing scope (likely `undefined` in strict mode) rather than the `compilerHost` instance. This works today only because the wrapped TS host methods don't currently dereference `this`, but it is incorrect and fragile.

This PR changes `.call(this, ...)` → `.call(compilerHost, ...)` so the delegated calls receive the proper context.

Additionally, this PR hardens the stylesheet-processing paths inside `readResource` and `transformResource`:

- Guards against `stylesheetProcessor` being `undefined` before calling its methods
- Uses null-coalescing for `referencedFiles` when spreading into arrays
- Replaces optional-chaining length checks with explicit truthiness checks for esbuild warnings/errors
- Adds a `?? ''` fallback on `cache.content` return and an explicit `: Promise<string>` return type on `readResource`

### Why

Arrow functions do not bind their own `this` — they inherit it from the enclosing lexical scope. When the returned host object's methods are called, `this` inside them is **not** the host object but whatever `this` was when `cacheCompilerHost` was invoked (typically `undefined` in strict mode). Passing that to `.call()` means the delegated method receives the wrong context. If a future TypeScript compiler-host implementation starts referencing `this` internally, these calls would break silently.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```