### PR TITLE
refactor: streamline entry point and package node retrieval

### DIFF
--- a/src/lib/ng-package/entry-point/analyse-sources.transform.ts
+++ b/src/lib/ng-package/entry-point/analyse-sources.transform.ts
@@ -7,7 +7,7 @@ import { Transform } from '../../graph/transform';
 import { cacheCompilerHost } from '../../ts/cache-compiler-host';
 import { debug } from '../../utils/log';
 import { ensureUnixPath } from '../../utils/path';
-import { EntryPointNode, PackageNode, isEntryPoint, isPackage } from '../nodes';
+import { EntryPointNode, findPackageNode, isEntryPoint } from '../nodes';
 
 export const analyseSourcesTransform: Transform = pipe(
   map(graph => {
@@ -34,7 +34,7 @@ function analyseEntryPoint(graph: BuildGraph, entryPoint: EntryPointNode, entryP
   const { oldPrograms, analysesSourcesFileCache, moduleResolutionCache } = entryPoint.cache;
   const oldProgram = oldPrograms && (oldPrograms['analysis'] as ts.Program | undefined);
   const { moduleId } = entryPoint.data.entryPoint;
-  const packageNode: PackageNode = graph.find(isPackage);
+  const packageNode = findPackageNode(graph);
   const primaryModuleId = packageNode.data.primary.moduleId;
 
   debug(`Analysing sources for ${moduleId}`);

--- a/src/lib/ng-package/entry-point/entry-point.transform.ts
+++ b/src/lib/ng-package/entry-point/entry-point.transform.ts
@@ -2,7 +2,7 @@ import { pipe, tap } from 'rxjs';
 import { STATE_DONE } from '../../graph/node';
 import { Transform } from '../../graph/transform';
 import * as log from '../../utils/log';
-import { isEntryPointInProgress } from '../nodes';
+import { findEntryPointInProgress } from '../nodes';
 
 /**
  * A re-write of the `transformSources()` script that transforms an entry point from sources to distributable format.
@@ -37,7 +37,7 @@ export const entryPointTransformFactory = (
   pipe(
     tap(graph => {
       // Peek the first entry point from the graph
-      const entryPoint = graph.find(isEntryPointInProgress());
+      const entryPoint = findEntryPointInProgress(graph);
       log.msg('\n------------------------------------------------------------------------------');
       log.msg(`Building entry point '${entryPoint.data.entryPoint.moduleId}'`);
       log.msg('------------------------------------------------------------------------------');
@@ -48,7 +48,7 @@ export const entryPointTransformFactory = (
     writeBundles,
     writePackage,
     tap(graph => {
-      const entryPoint = graph.find(isEntryPointInProgress());
+      const entryPoint = findEntryPointInProgress(graph);
       entryPoint.state = STATE_DONE;
     }),
   );

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -7,7 +7,7 @@ import { transformFromPromise } from '../../graph/transform';
 import { generateKey, readCacheEntry, saveCacheEntry } from '../../utils/cache';
 import { exists, mkdir, writeFile } from '../../utils/fs';
 import { ensureUnixPath } from '../../utils/path';
-import { EntryPointNode, isEntryPointInProgress } from '../nodes';
+import { findEntryPointInProgress } from '../nodes';
 import { NgPackagrOptions } from '../options.di';
 
 interface BundlesCache {
@@ -18,7 +18,7 @@ interface BundlesCache {
 
 export const writeBundlesTransform = (options: NgPackagrOptions) =>
   transformFromPromise(async graph => {
-    const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
+    const entryPoint = findEntryPointInProgress(graph);
     const { destinationFiles, entryPoint: ngEntryPoint, tsConfig } = entryPoint.data;
     const cache = entryPoint.cache;
     const { fesm2022Dir, esm2022, declarations, declarationsDir } = destinationFiles;

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -10,7 +10,7 @@ import { colors } from '../../utils/color';
 import { copyFile, mkdir, rmdir, stat, writeFile } from '../../utils/fs';
 import * as log from '../../utils/log';
 import { ensureUnixPath } from '../../utils/path';
-import { EntryPointNode, PackageNode, fileUrl, isEntryPoint, isPackage } from '../nodes';
+import { EntryPointNode, PackageNode, fileUrl, findPackageNode, isEntryPoint } from '../nodes';
 import { NgPackagrOptions } from '../options.di';
 import { NgPackage } from '../package';
 import { NgEntryPoint } from './entry-point';
@@ -23,7 +23,7 @@ export const writePackageTransform = (options: NgPackagrOptions) =>
     const entryPoints = graph.filter(isEntryPoint);
     const entryPoint = entryPoints.find(isInProgress);
     const ngEntryPoint: NgEntryPoint = entryPoint.data.entryPoint;
-    const ngPackageNode: PackageNode = graph.find(isPackage);
+    const ngPackageNode = findPackageNode(graph);
     const ngPackage = ngPackageNode.data;
     const { destinationFiles } = entryPoint.data;
 

--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -2,7 +2,7 @@ import type { NgtscProgram, ParsedConfiguration, Program } from '@angular/compil
 import type { RollupCache } from 'rollup';
 import ts from 'typescript';
 import { FileCache } from '../file-system/file-cache';
-import { ComplexPredicate } from '../graph/build-graph';
+import { BuildGraph, ComplexPredicate } from '../graph/build-graph';
 import { Node } from '../graph/node';
 import { by, isInProgress, isPending } from '../graph/select';
 import { AngularDiagnosticsCache } from '../ngc/angular-diagnostics-cache';
@@ -37,6 +37,24 @@ export function isEntryPointInProgress(): ComplexPredicate<EntryPointNode> {
 
 export function isEntryPointPending(): ComplexPredicate<EntryPointNode> {
   return by(n => isEntryPoint(n) && isPending(n));
+}
+
+export function findEntryPointInProgress(graph: BuildGraph): EntryPointNode {
+  const entryPoint = graph.find(isEntryPointInProgress());
+  if (!entryPoint) {
+    throw new Error('Could not find entry point in progress');
+  }
+
+  return entryPoint;
+}
+
+export function findPackageNode(graph: BuildGraph): PackageNode {
+  const packageNode: PackageNode | undefined = graph.find(isPackage);
+  if (!packageNode) {
+    throw new Error('Could not find package node in build graph');
+  }
+
+  return packageNode;
 }
 
 export function fileUrl(path: string): string {

--- a/src/lib/ng-package/package.transform.ts
+++ b/src/lib/ng-package/package.transform.ts
@@ -33,9 +33,9 @@ import {
   EntryPointNode,
   PackageNode,
   byEntryPoint,
+  findPackageNode,
   isEntryPoint,
   isEntryPointPending,
-  isPackage,
   ngUrl,
 } from './nodes';
 import { NgPackagrOptions } from './options.di';
@@ -132,7 +132,7 @@ const watchTransformFactory =
         const {
           data,
           cache: { sourcesFileCache },
-        } = graph.find(isPackage);
+        } = findPackageNode(graph);
         const { onFileChange, watcher } = createFileWatch([], [data.dest + '/'], options.poll);
         graph.watcher = watcher;
 

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -2,7 +2,7 @@ import { CompilerOptions, ParsedConfiguration } from '@angular/compiler-cli';
 import { join } from 'node:path';
 import ts from 'typescript';
 import { BuildGraph } from '../graph/build-graph';
-import { EntryPointNode, PackageNode, isEntryPointInProgress, isPackage } from '../ng-package/nodes';
+import { findEntryPointInProgress, findPackageNode } from '../ng-package/nodes';
 import { NgPackagrOptions } from '../ng-package/options.di';
 import { StylesheetProcessor } from '../styles/stylesheet-processor';
 import { augmentProgramWithVersioning, cacheCompilerHost } from '../ts/cache-compiler-host';
@@ -19,8 +19,8 @@ export async function compileSourceFiles(
   const { NgtscProgram, formatDiagnostics } = await import('@angular/compiler-cli');
   const { cacheDirectory, watch, cacheEnabled } = options;
   const tsConfigOptions: CompilerOptions = { ...tsConfig.options, ...extraOptions };
-  const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
-  const ngPackageNode: PackageNode = graph.find(isPackage);
+  const entryPoint = findEntryPointInProgress(graph);
+  const ngPackageNode = findPackageNode(graph);
   const inlineStyleLanguage = ngPackageNode.data.inlineStyleLanguage;
 
   const cacheDir = cacheEnabled && cacheDirectory;


### PR DESCRIPTION
Part of https://github.com/ng-packagr/ng-packagr/pull/3252

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added

## Description

Introduces two dedicated helper functions in `nodes.ts` to replace ad-hoc `graph.find(predicate)` patterns used throughout the codebase:

| Helper | Replaces |
|---|---|
| `findEntryPointInProgress(graph)` | `graph.find(isEntryPointInProgress())` |
| `findPackageNode(graph)` | `graph.find(isPackage)` |

Both helpers throw a descriptive error if the node is not found, eliminating the need for callers to handle `undefined` or cast types manually.

### Files changed

**`src/lib/ng-package/nodes.ts`** — Added `findEntryPointInProgress()` and `findPackageNode()` with null checks and clear error messages.

**6 call sites updated:**

- `src/lib/ngc/compile-source-files.ts`
- `src/lib/ng-package/entry-point/entry-point.transform.ts`
- `src/lib/ng-package/entry-point/write-bundles.transform.ts`
- `src/lib/ng-package/entry-point/write-package.transform.ts`
- `src/lib/ng-package/entry-point/analyse-sources.transform.ts`
- `src/lib/ng-package/package.transform.ts`

### Why

The existing pattern (`graph.find(isEntryPointInProgress())`) has two issues:

1. **Unsafe access** — `graph.find()` returns `T | undefined`, but callers access `.data` and `.cache` without null checks, relying on the assumption that the node always exists.
2. **Repetition** — The same predicate + find + implicit cast pattern is duplicated across 7 call sites.

The new helpers centralize the lookup and the invariant check, making the code safer and easier to follow.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```