### PR TITLE
fix: replace ansi-colors with Node built-in styleText and improve type safety

### DIFF
--- a/integration/watch/test-harness.ts
+++ b/integration/watch/test-harness.ts
@@ -21,7 +21,7 @@ export class TestHarness {
     this.testSrc = path.join(__dirname, testName);
     this.testDistPath = path.join(this.testTempPath, 'dist');
 
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
   }
 
   async initialize(): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/wasm-node": "^4.24.0",
     "ajv": "^8.17.1",
-    "ansi-colors": "^4.1.3",
     "browserslist": "^4.26.0",
     "chokidar": "^5.0.0",
     "commander": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.18.0
-      ansi-colors:
-        specifier: ^4.1.3
-        version: 4.1.3
       browserslist:
         specifier: ^4.26.0
         version: 4.28.1
@@ -1993,10 +1990,6 @@ packages:
   algoliasearch@5.49.2:
     resolution: {integrity: sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==}
     engines: {node: '>= 14.0.0'}
-
-  ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -6314,8 +6307,6 @@ snapshots:
       '@algolia/requester-browser-xhr': 5.49.2
       '@algolia/requester-fetch': 5.49.2
       '@algolia/requester-node-http': 5.49.2
-
-  ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
     dependencies:

--- a/src/lib/commands/build.command.ts
+++ b/src/lib/commands/build.command.ts
@@ -14,7 +14,7 @@ export interface CliArguments {
   /** Path to a tsconfig file. */
   config?: string;
   /** Enable and define the file watching poll time period in milliseconds */
-  poll? : number;
+  poll?: number;
 }
 
 /**
@@ -22,5 +22,10 @@ export interface CliArguments {
  *
  * @stable
  */
-export const build: Command<CliArguments, void> = opts =>
-  ngPackagr().forProject(opts.project).withTsConfig(opts.config).build({ watch: opts.watch, poll: opts.poll });
+export const build: Command<CliArguments, void> = opts => {
+  if (!opts) {
+    throw new Error('No options provided to the build command.');
+  }
+
+  return ngPackagr().forProject(opts.project).withTsConfig(opts.config).build({ watch: opts.watch, poll: opts.poll });
+};

--- a/src/lib/styles/bundler-context.ts
+++ b/src/lib/styles/bundler-context.ts
@@ -64,7 +64,7 @@ export class BundlerContext {
   #optionsFactory: BundlerOptionsFactory<BuildOptions & { metafile: true; write: false }>;
   #shouldCacheResult: boolean;
   #loadCache?: MemoryLoadResultCache;
-  readonly watchFiles = new Set<string>();
+  readonly watchFiles: Set<string> = new Set<string>();
 
   constructor(
     private workspaceRoot: string,
@@ -183,8 +183,10 @@ export class BundlerContext {
 
     // Return the successful build results
     return {
-      ...result,
       errors: undefined,
+      warnings: result.warnings,
+      metafile: result.metafile,
+      outputFiles: result.outputFiles as BuildOutputFile[],
     };
   }
 

--- a/src/lib/styles/component-stylesheets.ts
+++ b/src/lib/styles/component-stylesheets.ts
@@ -1,10 +1,19 @@
-import { OutputFile } from 'esbuild';
+import { Message, Metafile, OutputFile } from 'esbuild';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { BuildOutputFileType, BundleContextResult, BundlerContext } from './bundler-context';
 import { MemoryCache } from './cache';
 import { BundleStylesheetOptions, createStylesheetBundleOptions } from './stylesheets/bundle-options';
 import { shutdownSassWorkerPool } from './stylesheets/sass-language';
+
+export interface ComponentStylesheetResult {
+  errors: Message[] | undefined;
+  warnings: Message[];
+  contents: string;
+  outputFiles: OutputFile[];
+  metafile: Metafile | undefined;
+  referencedFiles: Set<string> | undefined;
+}
 
 /**
  * Bundles component stylesheets. A stylesheet can be either an inline stylesheet that
@@ -26,7 +35,7 @@ export class ComponentStylesheetBundler {
     private readonly incremental: boolean,
   ) {}
 
-  async bundleFile(entry: string) {
+  async bundleFile(entry: string): Promise<ComponentStylesheetResult> {
     const bundlerContext = await this.#fileContexts.getOrCreate(entry, () => {
       return new BundlerContext(this.options.workspaceRoot, this.incremental, loadCache => {
         const buildOptions = createStylesheetBundleOptions(this.options, loadCache);
@@ -40,7 +49,7 @@ export class ComponentStylesheetBundler {
     return this.extractResult(await bundlerContext.bundle(), bundlerContext.watchFiles);
   }
 
-  async bundleInline(data: string, filename: string, language = this.defaultInlineLanguage) {
+  async bundleInline(data: string, filename: string, language: string = this.defaultInlineLanguage): Promise<ComponentStylesheetResult> {
     // Use a hash of the inline stylesheet content to ensure a consistent identifier. External stylesheets will resolve
     // to the actual stylesheet file path.
     // TODO: Consider xxhash instead for hashing
@@ -118,10 +127,10 @@ export class ComponentStylesheetBundler {
     this.#fileContexts.clear();
     this.#inlineContexts.clear();
 
-    await Promise.allSettled([shutdownSassWorkerPool(), contexts.map(context => context.dispose())]);
+    await Promise.allSettled([shutdownSassWorkerPool(), ...contexts.map(context => context.dispose())]);
   }
 
-  private extractResult(result: BundleContextResult, referencedFiles: Set<string> | undefined) {
+  private extractResult(result: BundleContextResult, referencedFiles: Set<string> | undefined): ComponentStylesheetResult {
     let contents = '';
     let metafile;
     const outputFiles: OutputFile[] = [];

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -1,39 +1,33 @@
-import * as ansiColors from 'ansi-colors';
-import { WriteStream } from 'tty';
+import { styleText } from 'node:util';
 
-type AnsiColors = typeof ansiColors;
+type ColorFn = (text: string) => string;
 
-function supportColor(): boolean {
-  if (process.env.FORCE_COLOR !== undefined) {
-    // 2 colors: FORCE_COLOR = 0 (Disables colors), depth 1
-    // 16 colors: FORCE_COLOR = 1, depth 4
-    // 256 colors: FORCE_COLOR = 2, depth 8
-    // 16,777,216 colors: FORCE_COLOR = 3, depth 16
-    // See: https://nodejs.org/dist/latest-v12.x/docs/api/tty.html#tty_writestream_getcolordepth_env
-    // and https://github.com/nodejs/node/blob/b9f36062d7b5c5039498e98d2f2c180dca2a7065/lib/internal/tty.js#L106;
-    switch (process.env.FORCE_COLOR) {
-      case '':
-      case 'true':
-      case '1':
-      case '2':
-      case '3':
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  if (process.stdout instanceof WriteStream) {
-    return process.stdout.getColorDepth() > 1;
-  }
-
-  return false;
+interface Colors {
+  red: ColorFn;
+  yellow: ColorFn;
+  green: ColorFn;
+  blue: ColorFn;
+  white: ColorFn;
+  bold: ColorFn;
+  inverse: {
+    cyan: ColorFn;
+  };
 }
 
+type Format = Parameters<typeof styleText>[0];
 
-// Create a separate instance to prevent unintended global changes to the color configuration
-// Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
-const colors = (ansiColors as AnsiColors & { create: () => AnsiColors }).create();
-colors.enabled = supportColor();
+const color = (format: Format): ColorFn => {
+  return (text: string): string => styleText(format, text);
+};
 
-export { colors };
+export const colors: Colors = {
+  red: color('red'),
+  yellow: color('yellow'),
+  green: color('green'),
+  blue: color('blue'),
+  white: color('white'),
+  bold: color('bold'),
+  inverse: {
+    cyan: color(['inverse', 'cyan']),
+  },
+};

--- a/src/lib/utils/log.ts
+++ b/src/lib/utils/log.ts
@@ -1,35 +1,35 @@
 /* eslint-disable no-console */
 import { colors } from './color';
 
-export const error = (err: string | Error) => {
+export const error = (err: string | Error): void => {
   if (err instanceof Error) {
     console.error(colors.red('ERROR: ' + err.message));
 
     if (process.env.DEBUG) {
-      console.error(colors.red(err.stack) + '\n');
+      console.error(colors.red(err.stack ?? String(err)) + '\n');
     }
   } else {
     console.error(colors.red(err));
   }
 };
 
-export const warn = (msg: string) => {
+export const warn = (msg: string): void => {
   console.warn(colors.yellow('WARNING: ' + msg));
 };
 
-export const success = (msg: string) => {
+export const success = (msg: string): void => {
   console.log(colors.green(msg));
 };
 
-export const info = (msg: string) => {
+export const info = (msg: string): void => {
   console.log(colors.blue(msg));
 };
 
-export const msg = (msg: string) => {
+export const msg = (msg: string): void => {
   console.log(colors.white(msg));
 };
 
-export const debug = (msg: string) => {
+export const debug = (msg: string): void => {
   if (process.env.DEBUG) {
     console.log(colors.inverse.cyan(`[debug] ${msg}`));
   }


### PR DESCRIPTION
Part of https://github.com/ng-packagr/ng-packagr/pull/3252

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

### Replace `ansi-colors` with Node built-in `styleText`

**`src/lib/utils/color.ts`** — Replaces the `ansi-colors` third-party package with Node's built-in [`util.styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text) API (available since Node 20.12 / 21.7). This removes a runtime dependency and its custom `FORCE_COLOR` / `WriteStream` detection logic — `styleText` handles color support natively.

**`package.json`** — Removed `ansi-colors` from dependencies.

### Bug fixes

**`src/lib/styles/component-stylesheets.ts`** — Fixed a bug in `dispose()` where `Promise.allSettled` received a nested array instead of a flat list of promises:

```diff
-await Promise.allSettled([shutdownSassWorkerPool(), contexts.map(...)]);
+await Promise.allSettled([shutdownSassWorkerPool(), ...contexts.map(...)]);
```

Without the spread, the `contexts.map(...)` array was passed as a single element, meaning individual `dispose()` promises were never awaited.

**`src/lib/utils/log.ts`** — Fixed potential crash when `err.stack` is `undefined`:

```diff
-console.error(colors.red(err.stack) + '\n');
+console.error(colors.red(err.stack ?? String(err)) + '\n');
```

### Type safety improvements

| File | Change |
|---|---|
| `src/lib/utils/log.ts` | Added explicit `: void` return types to all exported log functions |
| `src/lib/styles/component-stylesheets.ts` | Added `ComponentStylesheetResult` interface and explicit return types on `bundleFile`, `bundleInline`, `extractResult` |
| `src/lib/styles/bundler-context.ts` | Explicit `Set<string>` type on `watchFiles`, replaced `...result` spread with explicit property assignment for type clarity |
| `src/lib/commands/build.command.ts` | Added null guard for `opts` parameter, fixed `poll? :` whitespace |

### Test stability

**`integration/watch/test-harness.ts`** — Increased `jasmine.DEFAULT_TIMEOUT_INTERVAL` from 10s to 15s to reduce flaky watch test failures.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```