### PR TITLE
feat: drop support for TypeScript 5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@angular/compiler-cli": "^22.0.0-next.3",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.9 <6.1"
+    "typescript": ">=6.0 <6.1"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
Narrows the peer dependency range to not allow versions lower than 6.

BREAKING CHANGE:
* TypeScript versions older than 6.0 are no longer supported.
