### PR TITLE
fix: map file extensions to correct typescript declaration file extension

### DIFF
--- a/integration/samples/file-extensions/index.ts
+++ b/integration/samples/file-extensions/index.ts
@@ -1,0 +1,13 @@
+
+
+export { foo } from "./src/foo.ts";
+export { baz } from "./src/baz.js";
+
+export { qxc } from "./src/qxc.mjs";
+// FIXME export { cqxc } from "./src/cqxc.cjs";
+
+export { esmts } from "./src/esm.mts";
+// FIXME export { cjsts } from "./src/cjs.cts";
+
+export { indexjs } from "./src/js";
+export { indexts } from "./src/ts";

--- a/integration/samples/file-extensions/ng-package.json
+++ b/integration/samples/file-extensions/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../src/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/integration/samples/file-extensions/ng-packagr-api.js
+++ b/integration/samples/file-extensions/ng-packagr-api.js
@@ -1,0 +1,12 @@
+const ngPackage = require('../../../dist/src/public_api');
+const path = require('path');
+
+ngPackage
+  .ngPackagr()
+  .forProject(path.join(__dirname, 'ng-package.json'))
+  .withTsConfig(path.join(__dirname, 'tsconfig.json'))
+  .build()
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/integration/samples/file-extensions/package.json
+++ b/integration/samples/file-extensions/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@sample/file-extensions",
+  "version": "0.0.1",
+  "private": true,
+  "peerDependencies": {},
+  "sideEffects": false
+}

--- a/integration/samples/file-extensions/src/bar.js
+++ b/integration/samples/file-extensions/src/bar.js
@@ -1,0 +1,1 @@
+export const bar = "bar";

--- a/integration/samples/file-extensions/src/bar.ts
+++ b/integration/samples/file-extensions/src/bar.ts
@@ -1,0 +1,3 @@
+
+
+export const bar = "bar";

--- a/integration/samples/file-extensions/src/baz.js
+++ b/integration/samples/file-extensions/src/baz.js
@@ -1,0 +1,3 @@
+
+
+export const baz = 'baz';

--- a/integration/samples/file-extensions/src/cjs.cjs
+++ b/integration/samples/file-extensions/src/cjs.cjs
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cjsts = void 0;
+exports.cjsts = "cjs.ts";

--- a/integration/samples/file-extensions/src/cjs.cts
+++ b/integration/samples/file-extensions/src/cjs.cts
@@ -1,0 +1,2 @@
+
+export const cjsts = "cjs.ts";

--- a/integration/samples/file-extensions/src/cqxc.cjs
+++ b/integration/samples/file-extensions/src/cqxc.cjs
@@ -1,0 +1,4 @@
+
+module.exports = {
+    cqxc: 'cqxc'
+};

--- a/integration/samples/file-extensions/src/esm.mjs
+++ b/integration/samples/file-extensions/src/esm.mjs
@@ -1,0 +1,1 @@
+export const esmts = "esm.ts";

--- a/integration/samples/file-extensions/src/esm.mts
+++ b/integration/samples/file-extensions/src/esm.mts
@@ -1,0 +1,3 @@
+
+
+export const esmts = "esm.ts";

--- a/integration/samples/file-extensions/src/foo.js
+++ b/integration/samples/file-extensions/src/foo.js
@@ -1,0 +1,2 @@
+import { bar } from "./bar.js";
+export const foo = "foo" + bar;

--- a/integration/samples/file-extensions/src/foo.ts
+++ b/integration/samples/file-extensions/src/foo.ts
@@ -1,0 +1,3 @@
+import { bar } from "./bar.ts";
+
+export const foo = "foo" + bar;

--- a/integration/samples/file-extensions/src/index.js
+++ b/integration/samples/file-extensions/src/index.js
@@ -1,0 +1,6 @@
+export { foo } from "./foo.js";
+export { baz } from "./baz.js";
+export { qxc } from "./qxc.mjs";
+export { cqxc } from "./cqxc.cjs";
+export { esmts } from "./esm.mjs";
+export { cjsts } from "./cjs.cjs";

--- a/integration/samples/file-extensions/src/js/index.js
+++ b/integration/samples/file-extensions/src/js/index.js
@@ -1,0 +1,2 @@
+
+export const indexjs = "index.js";

--- a/integration/samples/file-extensions/src/qxc.mjs
+++ b/integration/samples/file-extensions/src/qxc.mjs
@@ -1,0 +1,3 @@
+
+
+export const qxc = 'qxc';

--- a/integration/samples/file-extensions/src/ts/index.ts
+++ b/integration/samples/file-extensions/src/ts/index.ts
@@ -1,0 +1,2 @@
+
+export const indexts = "index.ts";

--- a/integration/samples/file-extensions/tsconfig.json
+++ b/integration/samples/file-extensions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "allowJs": true,
+    "target": "esnext",
+    "module": "es2022",
+    "moduleResolution": "bundler"
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  },
+  "files": ["index.ts", "src/foo.ts", "src/bar.ts", "src/baz.js", "src/qxc.mjs", "src/cqxc.cjs", "src/esm.mts", "src/cjs.cts"]
+}

--- a/src/lib/flatten/file-loader-plugin.ts
+++ b/src/lib/flatten/file-loader-plugin.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from 'node:path';
+import { dirname, format, parse, resolve } from 'node:path';
 import type { Plugin } from 'rollup';
 import { OutputFileCache } from '../ng-package/nodes';
 
@@ -8,7 +8,11 @@ import { ensureUnixPath } from '../utils/path';
 /**
  * Loads a file and it's map.
  */
-export function fileLoaderPlugin(fileCache: OutputFileCache, resolutionExtensions: string[]): Plugin {
+export function fileLoaderPlugin(
+  fileCache: OutputFileCache,
+  resolutionExtension: string,
+  resolutionExtensionMapping?: Record<string, string>
+): Plugin {
   return {
     name: 'file-loader',
     resolveId: function (id, importer) {
@@ -20,15 +24,43 @@ export function fileLoaderPlugin(fileCache: OutputFileCache, resolutionExtension
         return;
       }
 
-      const resolved = ensureUnixPath(resolve(dirname(importer), id));
+      const importerDirectory = dirname(importer);
+      const resolved = ensureUnixPath(resolve(importerDirectory, id));
       if (fileCache.has(resolved)) {
         return resolved;
       }
 
-      for (const suffix of resolutionExtensions) {
-        const potential = resolved + suffix;
-        if (fileCache.has(potential)) {
-          return potential;
+      const fileWithResolutionExtension = format({
+        name: resolved,
+        ext: resolutionExtension
+      });
+      if (fileCache.has(fileWithResolutionExtension)) {
+        return fileWithResolutionExtension;
+      }
+
+      const indexFilePath = format({
+        dir: resolved,
+        name: 'index',
+        ext: resolutionExtension
+      });
+      if (fileCache.has(indexFilePath)) {
+        return indexFilePath;
+      }
+
+      const {
+        ext
+      } = parse(resolved);
+
+      const mappedExtension = resolutionExtensionMapping?.[ext];
+
+      if (mappedExtension) {
+        const fileExtensionReplacedWithMappedExtension = format({
+          ...parse(resolved),
+          base: '',
+          ext: mappedExtension
+        });
+        if (fileCache.has(fileExtensionReplacedWithMappedExtension)) {
+          return fileExtensionReplacedWithMappedExtension;
         }
       }
     },

--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -41,10 +41,18 @@ export async function rollupBundleFile(
 
   if (dtsMode) {
     outExtension = '.d.ts';
-    plugins = [fileLoaderPlugin(opts.fileCache, ['.d.ts', '/index.d.ts']), dts({ sourcemap: opts.sourcemap })];
+    const dtsExtensionMapping = {
+      '.js': '.d.ts',
+      '.cjs': '.d.cts',
+      '.mjs': '.d.mts',
+      '.ts': '.d.ts',
+      '.mts': '.d.mts',
+      '.cts': '.d.cts',
+    }
+    plugins = [fileLoaderPlugin(opts.fileCache, '.d.ts', dtsExtensionMapping), dts({ sourcemap: opts.sourcemap })];
   } else {
     outExtension = '.mjs';
-    plugins = [fileLoaderPlugin(opts.fileCache, ['.js', '/index.js']), rollupJson()];
+    plugins = [fileLoaderPlugin(opts.fileCache, '.js'), rollupJson()];
   }
 
   // Create the bundle


### PR DESCRIPTION
Still looking into why .cjs and .cts file extensions are not working and need to add unit tests to ensure integration tests are run correctly. Looking for feedback on solution.

## I'm submitting a...

```
[X] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Fix issue #3281 by mapping file extensions of js, cjs, mjs, ts, cts, or mts file to the correct declaration file extension .d.ts, d.mts, or d.cts.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
