### PR TITLE
fix(ng-packagr): resolve imports with TS extensions in rollup

### DIFF
--- a/integration/samples/ts-extensions/ng-package.json
+++ b/integration/samples/ts-extensions/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../src/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public_api.ts"
+  }
+}

--- a/integration/samples/ts-extensions/ng-packagr-api.js
+++ b/integration/samples/ts-extensions/ng-packagr-api.js
@@ -1,0 +1,12 @@
+const ngPackage = require('../../../dist/src/public_api');
+const path = require('path');
+
+ngPackage
+  .ngPackagr()
+  .forProject(path.join(__dirname, 'ng-package.json'))
+  .withTsConfig(path.join(__dirname, 'tsconfig.ngc.json'))
+  .build()
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/integration/samples/ts-extensions/package.json
+++ b/integration/samples/ts-extensions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@sample/ts-extensions",
+  "description": "A sample library using TS files with extensions in imports",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/ng-packagr/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/common": "^4.1.3",
+    "@angular/core": "^4.1.3",
+    "rxjs": "^5.0.1"
+  }
+}

--- a/integration/samples/ts-extensions/public_api.ts
+++ b/integration/samples/ts-extensions/public_api.ts
@@ -1,0 +1,8 @@
+export * from './src/foo.ts';
+export * from './src/bar.js';
+
+export * from './src/cts-file.cts';
+export * from './src/cjs-file.cjs';
+
+export * from './src/mjs-file.mjs';
+export * from './src/mts-file.mts';

--- a/integration/samples/ts-extensions/specs/package.ts
+++ b/integration/samples/ts-extensions/specs/package.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe(`@sample/ts-extensions`, () => {
+  describe(`package.json`, () => {
+    let PACKAGE: any;
+    beforeAll(() => {
+      PACKAGE = JSON.parse(readFileSync(join(__dirname, '../dist/package.json'), 'utf-8'));
+    });
+
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should be named '@sample/ts-extensions'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/ts-extensions');
+    });
+  });
+});

--- a/integration/samples/ts-extensions/src/bar.ts
+++ b/integration/samples/ts-extensions/src/bar.ts
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/integration/samples/ts-extensions/src/cjs-file.cts
+++ b/integration/samples/ts-extensions/src/cjs-file.cts
@@ -1,0 +1,1 @@
+export const cjsValue = 'cjs';

--- a/integration/samples/ts-extensions/src/cts-file.cts
+++ b/integration/samples/ts-extensions/src/cts-file.cts
@@ -1,0 +1,1 @@
+export const ctsValue = 'cts';

--- a/integration/samples/ts-extensions/src/foo.ts
+++ b/integration/samples/ts-extensions/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/integration/samples/ts-extensions/src/mjs-file.mts
+++ b/integration/samples/ts-extensions/src/mjs-file.mts
@@ -1,0 +1,1 @@
+export const mtsValue = 'mts';

--- a/integration/samples/ts-extensions/src/mts-file.mts
+++ b/integration/samples/ts-extensions/src/mts-file.mts
@@ -1,0 +1,1 @@
+export const mjsValue = 'mjs';

--- a/integration/samples/ts-extensions/tsconfig.ngc.json
+++ b/integration/samples/ts-extensions/tsconfig.ngc.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "lib": ["dom", "es2022"]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/lib/flatten/file-loader-plugin.ts
+++ b/src/lib/flatten/file-loader-plugin.ts
@@ -6,21 +6,41 @@ import * as log from '../utils/log';
 import { ensureUnixPath } from '../utils/path';
 
 /**
+ * A regex used to strip the file extension from a file path.
+ */
+const FILE_EXT_REGEXP = /\.(c|m)?(t|j)s$/;
+
+/**
  * Loads a file and it's map.
  */
-export function fileLoaderPlugin(fileCache: OutputFileCache, resolutionExtensions: string[]): Plugin {
+export function fileLoaderPlugin(fileCache: OutputFileCache, resolutionExtensions: string[], dtsMode: boolean): Plugin {
   return {
     name: 'file-loader',
     resolveId: function (id, importer) {
-      if (fileCache.has(ensureUnixPath(id))) {
-        return id;
+      const normalizedId = ensureUnixPath(id);
+      if (fileCache.has(normalizedId)) {
+        return normalizedId;
+      }
+
+      const potentialId = normalizedId.endsWith('.d.ts')
+        ? normalizedId
+        : normalizedId.replace(FILE_EXT_REGEXP, (_match, p1) => {
+            if (dtsMode) {
+              return p1 ? `.d.${p1}ts` : '.d.ts';
+            }
+
+            return p1 ? `.${p1}js` : '.js';
+          });
+
+      if (fileCache.has(potentialId)) {
+        return potentialId;
       }
 
       if (!importer) {
         return;
       }
 
-      const resolved = ensureUnixPath(resolve(dirname(importer), id));
+      const resolved = ensureUnixPath(resolve(dirname(importer), potentialId));
       if (fileCache.has(resolved)) {
         return resolved;
       }
@@ -34,15 +54,14 @@ export function fileLoaderPlugin(fileCache: OutputFileCache, resolutionExtension
     },
     load: function (id) {
       log.debug(`file-loader ${id}`);
-      const idPosix = ensureUnixPath(id);
-      const data = fileCache.get(idPosix);
+      const data = fileCache.get(id);
       if (!data) {
         throw new Error(`Could not load '${id}' from memory.`);
       }
 
       return {
         code: data.content,
-        map: fileCache.get(`${idPosix}.map`)?.content,
+        map: fileCache.get(`${id}.map`)?.content,
       };
     },
   };

--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -41,10 +41,10 @@ export async function rollupBundleFile(
 
   if (dtsMode) {
     outExtension = '.d.ts';
-    plugins = [fileLoaderPlugin(opts.fileCache, ['.d.ts', '/index.d.ts']), dts({ sourcemap: opts.sourcemap })];
+    plugins = [fileLoaderPlugin(opts.fileCache, ['.d.ts', '/index.d.ts'], dtsMode), dts({ sourcemap: opts.sourcemap })];
   } else {
     outExtension = '.mjs';
-    plugins = [fileLoaderPlugin(opts.fileCache, ['.js', '/index.js']), rollupJson()];
+    plugins = [fileLoaderPlugin(opts.fileCache, ['.js', '/index.js'], dtsMode), rollupJson()];
   }
 
   // Create the bundle


### PR DESCRIPTION
This change fixes an issue where Rollup fails to resolve imports with TypeScript extensions (like .ts, .mts, .cts) when using TypeScript compiler options "allowImportingTsExtensions" and "rewriteRelativeImportExtensions".

Closes #3281

(cherry picked from commit 804c04bdfa408fca64610d55449a75d82ed43c49)
