### PR TITLE
fix: invalidate angularDiagnosticCache for html changes

### DIFF
--- a/integration/watch/basic.spec.ts
+++ b/integration/watch/basic.spec.ts
@@ -33,7 +33,7 @@ describe('basic', () => {
         });
       });
 
-      it('should recover from errors', done => {
+      it('should recover from template errors', done => {
         harness.copyTestCase('invalid-type');
 
         harness.onComplete(() => {
@@ -45,6 +45,19 @@ describe('basic', () => {
         harness.onFailure(error => {
           harness.copyTestCase('valid-text');
           expect(error.message).to.match(/is not assignable to type 'boolean'/);
+        });
+      });
+
+      it('should recover from template errors when switching between Signal Input and Decorator Input', done => {
+        harness.copyTestCase('input-to-decorator');
+
+        harness.onComplete(() => {
+          done();
+        });
+
+        harness.onFailure(error => {
+          harness.copyTestCase('input-to-decorator-fixed');
+          expect(error.message).to.match(/(is not callable|has no call signatures)/);
         });
       });
     });

--- a/integration/watch/basic/src/primary.component.html
+++ b/integration/watch/basic/src/primary.component.html
@@ -1,0 +1,1 @@
+<p>my-lib works! {{ x() }}</p>

--- a/integration/watch/basic/test_files/input-to-decorator-fixed/src/primary.component.html
+++ b/integration/watch/basic/test_files/input-to-decorator-fixed/src/primary.component.html
@@ -1,0 +1,1 @@
+<p>my-lib works! {{ x }}</p>

--- a/integration/watch/basic/test_files/input-to-decorator/src/primary.component.html
+++ b/integration/watch/basic/test_files/input-to-decorator/src/primary.component.html
@@ -1,0 +1,1 @@
+<p>my-lib works! {{ x() }}</p>

--- a/integration/watch/basic/test_files/input-to-decorator/src/primary.component.ts
+++ b/integration/watch/basic/test_files/input-to-decorator/src/primary.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   standalone: false,
@@ -6,5 +6,6 @@ import { Component, input } from '@angular/core';
   templateUrl: './primary.component.html',
 })
 export class PrimaryAngularComponent {
-  x = input(5);
+  @Input()
+  x = 5;
 }

--- a/integration/watch/basic/test_files/invalid-type/public_api.ts
+++ b/integration/watch/basic/test_files/invalid-type/public_api.ts
@@ -1,2 +1,3 @@
+export { PrimaryAngularComponent } from './src/primary.component';
 export { PrimaryAngularModule } from './src/primary.module';
 export const title: boolean = 'foo bar';

--- a/integration/watch/basic/test_files/valid-text/public_api.ts
+++ b/integration/watch/basic/test_files/valid-text/public_api.ts
@@ -1,2 +1,3 @@
+export { PrimaryAngularComponent } from './src/primary.component';
 export { PrimaryAngularModule } from './src/primary.module';
 export const title = 'foo bar';

--- a/integration/watch/basic/tsconfig.ngc.json
+++ b/integration/watch/basic/tsconfig.ngc.json
@@ -1,5 +1,7 @@
 {
-  "angularCompilerOptions": {},
+  "angularCompilerOptions": {
+    "strictTemplates": true
+  },
   "buildOnSave": false,
   "compileOnSave": false,
   "compilerOptions": {

--- a/integration/watch/intra-dependent.spec.ts
+++ b/integration/watch/intra-dependent.spec.ts
@@ -92,7 +92,9 @@ describe('intra-dependent', () => {
       harness.reSaveSrcFile('src/primary.component.html');
       await new Promise<void>(resolve =>
         harness.onFailure(error => {
-          expect(error.message).to.match(/Property \'count\' does not exist on type \'PrimaryAngularComponent\'./);
+          expect(error.message).to.match(
+            /(Property \'count\' does not exist on type \'PrimaryAngularComponent\'|Can\'t bind to \'count\' since it isn\'t a known property)/,
+          );
 
           resolve();
         }),

--- a/src/lib/file-system/file-watcher.ts
+++ b/src/lib/file-system/file-watcher.ts
@@ -137,6 +137,7 @@ export function invalidateEntryPointsAndCacheOnFileChange(
         continue;
       }
 
+      entryPoint.cache.angularDiagnosticCache.delete(filePath);
       entryPoint.cache.analysesSourcesFileCache.delete(filePath);
       isDirty = true;
     }

--- a/src/lib/ngc/angular-diagnostics-cache.ts
+++ b/src/lib/ngc/angular-diagnostics-cache.ts
@@ -3,6 +3,14 @@ import { Diagnostic, SourceFile } from 'typescript';
 export class AngularDiagnosticsCache {
   #cache: Map<string, readonly Diagnostic[]> = new Map();
 
+  delete(fileName: string): void {
+    this.#cache.delete(fileName);
+  }
+
+  has(sourceFile: SourceFile): boolean {
+    return this.#cache.has(sourceFile.fileName);
+  }
+
   update(sourceFile: SourceFile, diagnostics: readonly Diagnostic[]): void {
     this.#cache.set(sourceFile.fileName, diagnostics);
   }

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -159,7 +159,7 @@ export async function compileSourceFiles(
 
     // Only request Angular template diagnostics for affected files to avoid
     // overhead of template diagnostics for unchanged files.
-    if (affectedFiles.has(sourceFile)) {
+    if (affectedFiles.has(sourceFile) || !angularDiagnosticCache.has(sourceFile)) {
       const angularDiagnostics = angularCompiler.getDiagnosticsForFile(
         sourceFile,
         affectedFiles.size === 1 ? /** OptimizeFor.SingleFile **/ 0 : /** OptimizeFor.WholeProgram */ 1,


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

In watch mode with an angular component consisting of a TS and template HTML file: after introducing an issue in the template by changing the TS code and then changing the HTML to resolve the issue, the issue would not disappear and watch mode would need to be restarted manually. After some investigation I found this was due to the `angularDiagnosticCache` only being invalidated on TS updates (`affectedFiles`). In this PR the cached diagnostics for changed HTML files will be deleted as they need to be regenerated.

I have made the fix for 21.x as that is where I am affected, but it should also be applicable for the main branch.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
