### PR TITLE
fix(ng-packagr): invalidate angularDiagnosticCache for html changes

### DIFF
--- a/integration/watch/basic.spec.ts
+++ b/integration/watch/basic.spec.ts
@@ -33,7 +33,7 @@ describe('basic', () => {
         });
       });
 
-      it('should recover from errors', done => {
+      it('should recover from template errors', done => {
         harness.copyTestCase('invalid-type');
 
         harness.onComplete(() => {
@@ -45,6 +45,19 @@ describe('basic', () => {
         harness.onFailure(error => {
           harness.copyTestCase('valid-text');
           expect(error.message).to.match(/is not assignable to type 'boolean'/);
+        });
+      });
+
+      it('should recover from template errors when switching between Signal Input and Decorator Input', done => {
+        harness.copyTestCase('input-to-decorator');
+
+        harness.onComplete(() => {
+          done();
+        });
+
+        harness.onFailure(error => {
+          harness.copyTestCase('input-to-decorator-fixed');
+          expect(error.message).to.match(/(is not callable|has no call signatures)/);
         });
       });
     });

--- a/integration/watch/basic/src/primary.component.html
+++ b/integration/watch/basic/src/primary.component.html
@@ -1,0 +1,1 @@
+<p>my-lib works! {{x()}}</p>

--- a/integration/watch/basic/test_files/input-to-decorator-fixed/src/primary.component.html
+++ b/integration/watch/basic/test_files/input-to-decorator-fixed/src/primary.component.html
@@ -1,0 +1,1 @@
+<p>my-lib works! {{x}}</p>

--- a/integration/watch/basic/test_files/input-to-decorator/src/primary.component.html
+++ b/integration/watch/basic/test_files/input-to-decorator/src/primary.component.html
@@ -1,0 +1,1 @@
+<p>my-lib works! {{x()}}</p>

--- a/integration/watch/basic/test_files/input-to-decorator/src/primary.component.ts
+++ b/integration/watch/basic/test_files/input-to-decorator/src/primary.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   standalone: false,
@@ -6,5 +6,6 @@ import { Component, input } from '@angular/core';
   templateUrl: './primary.component.html',
 })
 export class PrimaryAngularComponent {
-  x = input(5);
+  @Input()
+  x = 5;
 }

--- a/integration/watch/basic/tsconfig.ngc.json
+++ b/integration/watch/basic/tsconfig.ngc.json
@@ -1,5 +1,7 @@
 {
-  "angularCompilerOptions": {},
+  "angularCompilerOptions": {
+    "strictTemplates": true
+  },
   "buildOnSave": false,
   "compileOnSave": false,
   "compilerOptions": {

--- a/src/lib/file-system/file-watcher.ts
+++ b/src/lib/file-system/file-watcher.ts
@@ -137,6 +137,7 @@ export function invalidateEntryPointsAndCacheOnFileChange(
         continue;
       }
 
+      entryPoint.cache.angularDiagnosticCache.delete(filePath);
       entryPoint.cache.analysesSourcesFileCache.delete(filePath);
       isDirty = true;
     }

--- a/src/lib/ngc/angular-diagnostics-cache.ts
+++ b/src/lib/ngc/angular-diagnostics-cache.ts
@@ -3,6 +3,10 @@ import { Diagnostic, SourceFile } from 'typescript';
 export class AngularDiagnosticsCache {
   #cache: Map<string, readonly Diagnostic[]> = new Map();
 
+  delete(fileName: string): void {
+    this.#cache.delete(fileName);
+  }
+
   update(sourceFile: SourceFile, diagnostics: readonly Diagnostic[]): void {
     this.#cache.set(sourceFile.fileName, diagnostics);
   }


### PR DESCRIPTION
When an external template HTML file changes, we need to make sure that any stale template compilation diagnostics cached against the component's .ts file are cleared. Otherwise, on subsequent incremental watch compilations, the stale diagnostics (such as errors) will persist even after the template errors are resolved.

This change invalidates the cached Angular diagnostics for the affected files when resource/HTML files change.

An integration watch spec has been added to verify template error recovery when switching back and forth between Signal Inputs and Decorator Inputs.