### PR TITLE
fix(ng-packagr): update template tests and fix flaky watch spec on 21.2.x

### DIFF
--- a/integration/watch/basic/src/primary.component.html
+++ b/integration/watch/basic/src/primary.component.html
@@ -1,1 +1,1 @@
-<p>my-lib works! {{x()}}</p>
+<p>my-lib works! {{ x() }}</p>

--- a/integration/watch/basic/test_files/input-to-decorator-fixed/src/primary.component.html
+++ b/integration/watch/basic/test_files/input-to-decorator-fixed/src/primary.component.html
@@ -1,1 +1,1 @@
-<p>my-lib works! {{x}}</p>
+<p>my-lib works! {{ x }}</p>

--- a/integration/watch/basic/test_files/input-to-decorator/src/primary.component.html
+++ b/integration/watch/basic/test_files/input-to-decorator/src/primary.component.html
@@ -1,1 +1,1 @@
-<p>my-lib works! {{x()}}</p>
+<p>my-lib works! {{ x() }}</p>

--- a/integration/watch/intra-dependent.spec.ts
+++ b/integration/watch/intra-dependent.spec.ts
@@ -92,7 +92,9 @@ describe('intra-dependent', () => {
       harness.reSaveSrcFile('src/primary.component.html');
       await new Promise<void>(resolve =>
         harness.onFailure(error => {
-          expect(error.message).to.match(/Property \'count\' does not exist on type \'PrimaryAngularComponent\'./);
+          expect(error.message).to.match(
+            /(Property \'count\' does not exist on type \'PrimaryAngularComponent\'|Can\'t bind to \'count\' since it isn\'t a known property)/,
+          );
 
           resolve();
         }),


### PR DESCRIPTION
This Pull Request applies the formatting updates for the watch template tests and fixes a flaky assertion in the `should always fail when there are errors in the component.` watch spec on the `21.2.x` branch.

The assertion has been broadened to match either the primary entry point's error (`Property 'count' does not exist on type 'PrimaryAngularComponent'`) or the secondary entry point's binding error (`Can't bind to 'count' since it isn't a known property of 'ng-component'`), preventing intermittent test failures.