### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/integration/samples/issue-852/foo/public-api.ts
+++ b/integration/samples/issue-852/foo/public-api.ts
@@ -1,4 +1,3 @@
-import { Platform } from '@angular/cdk/platform';
 import { Inject, Injectable, Optional } from '@angular/core';
 import { BAR_TOKEN } from '@my/issue-852/bar';
 


### PR DESCRIPTION
The correct fix is to delete the unused named import from `@angular/cdk/platform` while leaving behavior unchanged.

Specifically in `integration/samples/issue-852/foo/public-api.ts`, remove line 1:

- `import { Platform } from '@angular/cdk/platform';`

No other code changes are needed because `Platform` is not referenced elsewhere in the snippet. This preserves existing functionality and resolves the CodeQL finding cleanly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._