### PR TITLE
Fix for Useless conditional

### DIFF
--- a/src/lib/ng-package/discover-packages.ts
+++ b/src/lib/ng-package/discover-packages.ts
@@ -75,7 +75,7 @@ async function resolveUserPackage(folderPathOrFilePath: string, isSecondary = fa
         throw new Error(`Cannot discover package sources at ${folderPathOrFilePath} as 'package.json' was not found.`);
       }
 
-      if (packageJson && typeof packageJson !== 'object') {
+      if (typeof packageJson !== 'object') {
         throw new Error(`Invalid 'package.json' at ${folderPathOrFilePath}.`);
       }
     }


### PR DESCRIPTION
To fix this without changing behavior, remove the redundant truthiness check from line 78 and keep only the type validation.

Best change in `src/lib/ng-package/discover-packages.ts`:
- Replace:
  - `if (packageJson && typeof packageJson !== 'object') {`
- With:
  - `if (typeof packageJson !== 'object') {`

Why this is correct:
- `packageJson` has already been checked for falsy and throws at lines 74–76.
- So at line 78, checking `packageJson && ...` is unnecessary.
- This preserves all runtime behavior and resolves the CodeQL warning.

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._