### PR TITLE
fix(ng-packagr): generate specific .npmignore entries for secondary e…

### DIFF
--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -48,10 +48,26 @@ export const writePackageTransform = (options: NgPackagrOptions) =>
         spinner.start('Writing package manifest');
         if (!options.watch) {
           const primary = ngPackageNode.data.primary;
-          await writeFile(
-            path.join(primary.destinationPath, '.npmignore'),
-            `# Nested package.json's are only needed for development.\n**/package.json`,
-          );
+
+          const nestedPackageJsons: string[] = [];
+          // Secondary entry-points package.json
+          for (const { data } of entryPoints) {
+            if (!data.entryPoint.isSecondaryEntryPoint) {
+              continue;
+            }
+
+            const packageJsonPath = ensureUnixPath(
+              path.join(path.relative(primary.destinationPath, data.entryPoint.destinationPath), 'package.json'),
+            );
+            nestedPackageJsons.push(packageJsonPath);
+          }
+
+          if (nestedPackageJsons.length) {
+            await writeFile(
+              path.join(primary.destinationPath, '.npmignore'),
+              `# Nested package.json's are only needed for development.\n${nestedPackageJsons.join('\n')}`,
+            );
+          }
         }
 
         const { compilationMode } = entryPoint.data.tsConfig.options;


### PR DESCRIPTION
…ntry-point package.json files

Previously, a wildcard `**/package.json` entry was added to the `.npmignore` file of the primary entry-point to prevent publishing nested `package.json` files. However, this wildcard is too broad and can inadvertently exclude legitimate `package.json` files that should be packaged (such as those in assets or fixtures). This commit resolves the issue by targeting only the specific, auto-generated `package.json` files of secondary entry-points. We now compute their paths relative to the primary destination and list them individually in the `.npmignore` file, ensuring other nested `package.json` files are not affected.

Closes #3343
