### PR TITLE
fix(ng-packagr): log correct diagnostics array for warnings

### DIFF
--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -182,7 +182,7 @@ export async function compileSourceFiles(
   }
 
   if (otherDiagnostics.length) {
-    log.msg(formatDiagnostics(errorDiagnostics));
+    log.msg(formatDiagnostics(otherDiagnostics));
   }
 
   if (errorDiagnostics.length) {


### PR DESCRIPTION
When non-critical compiler warnings/diagnostics are collected, the code was mistakenly formatting and logging the `errorDiagnostics` array instead of the `otherDiagnostics` array. Because `errorDiagnostics` is either empty or contains errors that would be thrown anyway, warnings were never actually printed to the console.

This change corrects the variable to format and log `otherDiagnostics`.

Fixes #3346
