### PR TITLE
fix(ng-packagr): pin rollup-plugin-dts to ~6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ora": "^9.0.0",
     "piscina": "^5.0.0",
     "postcss": "^8.4.47",
-    "rollup-plugin-dts": "^6.4.0",
+    "rollup-plugin-dts": "~6.4.1",
     "rxjs": "^7.8.1",
     "sass": "^1.81.0",
     "tinyglobby": "^0.2.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         specifier: ^8.4.47
         version: 8.5.20
       rollup-plugin-dts:
-        specifier: ^6.4.0
+        specifier: ~6.4.1
         version: 6.4.1(rollup@4.62.2)(typescript@6.0.3)
       rxjs:
         specifier: ^7.8.1


### PR DESCRIPTION
`rollup-plugin-dts@6.5.0` updated its `magic-string` dependency to `^1.1.0`. `magic-string` 1.x is pure ESM, which causes CommonJS interop issues when required by `rollup-plugin-dts.cjs`, throwing `TypeError: MagicString is not a constructor`.

See: https://github.com/Swatinem/rollup-plugin-dts/issues/404

Closes https://github.com/angular/angular-cli/issues/33743