### PR TITLE
fix: pin rollup-plugin-dts to ~6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ora": "^9.0.0",
     "piscina": "^5.0.0",
     "postcss": "^8.4.47",
-    "rollup-plugin-dts": "^6.4.0",
+    "rollup-plugin-dts": "~6.4.1",
     "rxjs": "^7.8.1",
     "sass": "^1.81.0",
     "tinyglobby": "^0.2.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^8.4.47
         version: 8.5.6
       rollup-plugin-dts:
-        specifier: ^6.4.0
-        version: 6.4.0(rollup@4.57.1)(typescript@5.9.3)
+        specifier: ~6.4.1
+        version: 6.4.1(rollup@4.57.1)(typescript@5.9.3)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -4264,9 +4264,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup-plugin-dts@6.4.0:
-    resolution: {integrity: sha512-2i00A5UoPCoDecLEs13Eu105QegSGfrbp1sDeUj/54LKGmv6XFHDxWKC6Wsb4BobGUWYVCWWjmjAc8bXXbXH/Q==}
-    engines: {node: '>=16'}
+  rollup-plugin-dts@6.4.1:
+    resolution: {integrity: sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==}
+    engines: {node: '>=20'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0 || ^6.0
@@ -9012,7 +9012,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
 
-  rollup-plugin-dts@6.4.0(rollup@4.57.1)(typescript@5.9.3):
+  rollup-plugin-dts@6.4.1(rollup@4.57.1)(typescript@5.9.3):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5


### PR DESCRIPTION
`rollup-plugin-dts@6.5.0` updated its `magic-string` dependency to `^1.1.0`. `magic-string` 1.x is pure ESM, which causes CommonJS interop issues when required by `rollup-plugin-dts.cjs`, throwing `TypeError: MagicString is not a constructor`.

Closes https://github.com/angular/angular-cli/issues/33743