### PR TITLE
feat(ng-packagr): transform supported browsers to targets using lowest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "rolldown-plugin-dts": "^0.28.0",
     "rxjs": "^7.8.1",
     "sass": "^1.81.0",
+    "semver": "^7.8.5",
     "tinyglobby": "^0.2.12"
   },
   "peerDependencies": {
@@ -82,6 +83,7 @@
     "@types/jasmine": "^6.0.0",
     "@types/less": "^3.0.2",
     "@types/node": "^20.0.0",
+    "@types/semver": "^7.8.0",
     "@typescript-eslint/eslint-plugin": "8.66.0",
     "@typescript-eslint/parser": "8.66.0",
     "chai": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       sass:
         specifier: ^1.81.0
         version: 1.100.0
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       tinyglobby:
         specifier: ^0.2.12
         version: 0.2.17
@@ -119,6 +122,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.42
+      '@types/semver':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@typescript-eslint/eslint-plugin':
         specifier: 8.66.0
         version: 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@1.21.7)(supports-color@11.0.0))(supports-color@11.0.0)(typescript@6.0.3))(eslint@10.8.0(jiti@1.21.7)(supports-color@11.0.0))(supports-color@11.0.0)(typescript@6.0.3)
@@ -2489,6 +2495,9 @@ packages:
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@types/semver@7.8.0':
+    resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
 
   '@types/stack-trace@0.0.33':
     resolution: {integrity: sha512-O7in6531Bbvlb2KEsJ0dq0CHZvc3iWSR5ZYMtvGgnHA56VgriAN/AU2LorfmcvAl2xc9N5fbCTRyMRRl8nd74g==}
@@ -5195,11 +5204,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -5940,7 +5944,7 @@ snapshots:
       chokidar: 5.0.0
       convert-source-map: 1.9.0
       reflect-metadata: 0.2.2
-      semver: 7.8.4
+      semver: 7.8.5
       tslib: 2.8.1
       yargs: 18.0.0
     optionalDependencies:
@@ -6087,7 +6091,7 @@ snapshots:
       import-meta-resolve: 4.2.0
       json5: 2.2.3
       obug: 2.1.4
-      semver: 7.8.4
+      semver: 7.8.5
 
   '@babel/generator@8.0.0':
     dependencies:
@@ -6165,7 +6169,7 @@ snapshots:
     dependencies:
       '@simple-libs/child-process-utils': 2.0.0
       '@simple-libs/stream-utils': 2.0.0
-      semver: 7.8.4
+      semver: 7.8.5
     optionalDependencies:
       conventional-commits-filter: 6.0.1
       conventional-commits-parser: 7.1.1
@@ -7592,7 +7596,7 @@ snapshots:
     dependencies:
       '@pnpm/crypto.hash': 1000.2.2
       '@pnpm/types': 1001.3.0
-      semver: 7.8.4
+      semver: 7.8.5
 
   '@pnpm/graceful-fs@1000.1.0':
     dependencies:
@@ -7940,6 +7944,8 @@ snapshots:
   '@types/retry@0.12.0': {}
 
   '@types/semver@7.7.1': {}
+
+  '@types/semver@7.8.0': {}
 
   '@types/stack-trace@0.0.33': {}
 
@@ -10260,7 +10266,7 @@ snapshots:
     dependencies:
       hosted-git-info: 10.1.1
       proc-log: 7.0.0
-      semver: 7.8.4
+      semver: 7.8.5
       validate-npm-package-name: 8.0.0
 
   nth-check@2.1.1:
@@ -10958,8 +10964,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.4: {}
-
   semver@7.8.5: {}
 
   send@1.2.1(supports-color@11.0.0):
@@ -11113,7 +11117,7 @@ snapshots:
       figures: 3.2.0
       find-up: 5.0.0
       git-semver-tags: 4.1.1
-      semver: 7.8.4
+      semver: 7.8.5
       stringify-package: 1.0.1
       yargs: 16.2.0
 

--- a/src/lib/styles/stylesheet-processor.spec.ts
+++ b/src/lib/styles/stylesheet-processor.spec.ts
@@ -1,0 +1,52 @@
+import { transformSupportedBrowsersToTargets } from './stylesheet-processor';
+
+describe('transformSupportedBrowsersToTargets', () => {
+  it('should return the smallest version for each browser', () => {
+    const targets = transformSupportedBrowsersToTargets([
+      'chrome 122',
+      'chrome 120',
+      'chrome 121',
+      'firefox 116',
+      'firefox 115',
+      'safari 17.0',
+      'safari 16.4',
+    ]);
+
+    expect(targets).toEqual(['chrome120.0', 'firefox115.0', 'safari16.4']);
+  });
+
+  it('should handle version ranges and pick the lowest version', () => {
+    const targets = transformSupportedBrowsersToTargets(['ios_saf 15.4', 'ios_saf 15.2-15.3', 'ios_saf 16.0']);
+
+    expect(targets).toEqual(['ios15.2']);
+  });
+
+  it('should handle Safari TP (Technology Preview)', () => {
+    const targetsWithOlderSafari = transformSupportedBrowsersToTargets(['safari TP', 'safari 16.4']);
+    expect(targetsWithOlderSafari).toEqual(['safari16.4']);
+
+    const targetsWithOnlyTP = transformSupportedBrowsersToTargets(['safari TP']);
+    expect(targetsWithOnlyTP).toEqual(['safari999']);
+  });
+
+  it('should ignore browsers not supported by esbuild', () => {
+    const targets = transformSupportedBrowsersToTargets(['android 4.4', 'samsung 22', 'kaios 2.5', 'chrome 115']);
+
+    expect(targets).toEqual(['chrome115.0']);
+  });
+
+  it('should return empty array for empty supportedBrowsers', () => {
+    const targets = transformSupportedBrowsersToTargets([]);
+    expect(targets).toEqual([]);
+  });
+
+  it('should handle malformed or incomplete browser strings gracefully', () => {
+    const targets = transformSupportedBrowsersToTargets(['chrome', 'firefox ', '']);
+    expect(targets).toEqual([]);
+  });
+
+  it('should handle single major versions by appending .0', () => {
+    const targets = transformSupportedBrowsersToTargets(['chrome 120', 'edge 120']);
+    expect(targets).toEqual(['chrome120.0', 'edge120.0']);
+  });
+});

--- a/src/lib/styles/stylesheet-processor.ts
+++ b/src/lib/styles/stylesheet-processor.ts
@@ -1,4 +1,5 @@
 import browserslist from 'browserslist';
+import { coerce, compare } from 'semver';
 import { NgPackageEntryConfig } from '../../ng-entrypoint.schema';
 import { ComponentStylesheetBundler } from './component-stylesheets';
 import { CssUrl } from './css-url.enum';
@@ -40,34 +41,86 @@ export class StylesheetProcessor extends ComponentStylesheetBundler {
   }
 }
 
-function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): string[] {
-  const transformed: string[] = [];
+/**
+ * Compares two target version strings.
+ *
+ * This function is used to determine the lowest version for a given browser target.
+ *
+ * @param a The first version string.
+ * @param b The second version string.
+ * @returns A negative value if `a` is lower than `b`, a positive value if `a` is higher than `b`, and 0 if they are equal.
+ */
+function compareTargetVersions(a: string, b: string): number {
+  const aVersion = coerce(a);
+  const bVersion = coerce(b);
 
-  // https://esbuild.github.io/api/#target
-  const esBuildSupportedBrowsers = new Set(['safari', 'firefox', 'edge', 'chrome', 'ios']);
+  if (!aVersion || !bVersion) {
+    return aVersion ? -1 : bVersion ? 1 : 0;
+  }
+
+  return compare(aVersion, bVersion);
+}
+
+// https://esbuild.github.io/api/#target
+const ESBUILD_SUPPORTED_BROWSERS: ReadonlySet<string> = new Set([
+  'chrome',
+  'edge',
+  'firefox',
+  'ie',
+  'ios',
+  'node',
+  'opera',
+  'safari',
+]);
+
+/**
+ * Transform browserlists result to esbuild target.
+ *
+ * Only the lowest version for each browser is returned to avoid issues with esbuild and rolldown
+ * when multiple versions of the same target engine are specified.
+ *
+ * @see https://esbuild.github.io/api/#target
+ * @see https://github.com/evanw/esbuild/issues/4509
+ * @see https://github.com/rolldown/rolldown/issues/10633
+ */
+export function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): string[] {
+  const browsers = new Map<string, string>();
 
   for (const browser of supportedBrowsers) {
-    let [browserName, version] = browser.split(' ');
+    let [browserName, version] = browser.toLowerCase().split(' ');
+    if (!browserName || !version) {
+      continue;
+    }
 
     // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
     if (browserName === 'ios_saf') {
       browserName = 'ios';
     }
 
+    if (!ESBUILD_SUPPORTED_BROWSERS.has(browserName)) {
+      continue;
+    }
+
     // browserslist uses ranges `15.2-15.3` versions but only the lowest is required
     // to perform minimum supported feature checks. esbuild also expects a single version.
     [version] = version.split('-');
 
-    if (esBuildSupportedBrowsers.has(browserName)) {
-      if (browserName === 'safari' && version === 'tp') {
-        // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
-        // a Technology Preview (TP) of Safari is assumed to support all currently known features.
-        version = '999';
-      }
+    if (browserName === 'safari' && version === 'tp') {
+      // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
+      // a Technology Preview (TP) of Safari is assumed to support all currently known features.
+      version = '999';
+    } else if (!version.includes('.')) {
+      // A lone major version is considered by esbuild to include all minor versions. However,
+      // browserslist does not and is also inconsistent in its `.0` version naming. For example,
+      // Safari 15.0 is named `safari 15` but Safari 16.0 is named `safari 16.0`.
+      version += '.0';
+    }
 
-      transformed.push(browserName + version);
+    const current = browsers.get(browserName);
+    if (!current || compareTargetVersions(version, current) < 0) {
+      browsers.set(browserName, version);
     }
   }
 
-  return transformed.length ? transformed : undefined;
+  return Array.from(browsers, ([browserName, version]) => browserName + version);
 }


### PR DESCRIPTION
Transform browserslist results to only retain the lowest version for each browser target to avoid issues with esbuild and rolldown when multiple versions of the same engine are specified.

Also expand `ESBUILD_SUPPORTED_BROWSERS` to include all supported browsers as `ReadonlySet<string>` and ensure lone major versions are properly formatted.