### PR TITLE
perf(ng-packagr): cache declaration diagnostics and optimize incremental emit

### DIFF
--- a/src/lib/file-system/file-watcher.ts
+++ b/src/lib/file-system/file-watcher.ts
@@ -138,6 +138,7 @@ export function invalidateEntryPointsAndCacheOnFileChange(
       }
 
       entryPoint.cache.angularDiagnosticCache.delete(filePath);
+      entryPoint.cache.declarationDiagnosticCache?.delete(filePath);
       entryPoint.cache.analysesSourcesFileCache.delete(filePath);
       isDirty = true;
     }

--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -86,6 +86,7 @@ export class EntryPointNode extends Node {
       moduleResolutionCache,
       outputCache: new Map(),
       angularDiagnosticCache: new AngularDiagnosticsCache(),
+      declarationDiagnosticCache: new AngularDiagnosticsCache(),
     };
   }
 
@@ -99,6 +100,7 @@ export class EntryPointNode extends Node {
     oldNgtscProgram?: NgtscProgram;
     oldBuilder?: ts.EmitAndSemanticDiagnosticsBuilderProgram;
     angularDiagnosticCache: AngularDiagnosticsCache;
+    declarationDiagnosticCache: AngularDiagnosticsCache;
   };
 
   declare data: {

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -138,24 +138,29 @@ export async function compileSourceFiles(
   await angularCompiler.analyzeAsync();
 
   // Collect source file specific diagnostics
-  const angularDiagnosticCache = cache.angularDiagnosticCache;
+  const { angularDiagnosticCache, declarationDiagnosticCache } = cache;
+
   for (const sourceFile of builder.getSourceFiles()) {
     if (ignoreForDiagnostics.has(sourceFile)) {
       continue;
     }
 
-    allDiagnostics.push(
-      ...builder.getSyntacticDiagnostics(sourceFile),
-      ...builder.getSemanticDiagnostics(sourceFile),
-      // We use the `typeScriptProgram` instead of `builder` here as a
-      // performance workaround for: https://github.com/microsoft/TypeScript/issues/60970
-      ...typeScriptProgram.getDeclarationDiagnostics(sourceFile),
-    );
+    allDiagnostics.push(...builder.getSyntacticDiagnostics(sourceFile), ...builder.getSemanticDiagnostics(sourceFile));
 
-    // Declaration files cannot have template diagnostics
+    // Declaration files cannot have declaration or template diagnostics
     if (sourceFile.isDeclarationFile) {
       continue;
     }
+
+    // Only request declaration diagnostics for affected or uncached files
+    if (affectedFiles.has(sourceFile) || !declarationDiagnosticCache.has(sourceFile)) {
+      // We use the `typeScriptProgram` instead of `builder` here as a
+      // performance workaround for: https://github.com/microsoft/TypeScript/issues/60970
+      const declarationDiagnostics = typeScriptProgram.getDeclarationDiagnostics(sourceFile);
+      declarationDiagnosticCache.update(sourceFile, declarationDiagnostics);
+    }
+
+    allDiagnostics.push(...declarationDiagnosticCache.get(sourceFile));
 
     // Only request Angular template diagnostics for affected files to avoid
     // overhead of template diagnostics for unchanged files.
@@ -191,6 +196,18 @@ export async function compileSourceFiles(
 
   const transformers = angularCompiler.prepareEmit().transformers;
 
+  const writeFile: ts.WriteFileCallback = (fileName, data, writeByteOrderMark, onError, sourceFiles) => {
+    if (sourceFiles) {
+      for (const sourceFile of sourceFiles) {
+        if (!sourceFile.isDeclarationFile) {
+          angularCompiler.incrementalCompilation.recordSuccessfulEmit(sourceFile);
+        }
+      }
+    }
+
+    tsCompilerHost.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
+  };
+
   if ('getSemanticDiagnosticsOfNextAffectedFile' in builder) {
     while (
       builder.emitNextAffectedFile((fileName, data, writeByteOrderMark, onError, sourceFiles) => {
@@ -204,7 +221,7 @@ export async function compileSourceFiles(
   }
 
   for (const sourceFile of builder.getSourceFiles()) {
-    if (ignoreForEmit.has(sourceFile)) {
+    if (sourceFile.isDeclarationFile || ignoreForEmit.has(sourceFile)) {
       continue;
     }
 
@@ -212,7 +229,6 @@ export async function compileSourceFiles(
       continue;
     }
 
-    builder.emit(sourceFile, undefined, undefined, undefined, transformers);
-    angularCompiler.incrementalCompilation.recordSuccessfulEmit(sourceFile);
+    builder.emit(sourceFile, writeFile, undefined, undefined, transformers);
   }
 }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Cache TypeScript declaration diagnostics per entry point so that unchanged files avoid recomputing declaration diagnostics during incremental/watch builds.

- Introduce `declarationDiagnosticCache` in `EntryPointNode` and invalidate on file change in `invalidateEntryPointsAndCacheOnFileChange`.
- Skip declaration diagnostic checks and emit for `.d.ts` files in `compileSourceFiles`.
- Accurately track Angular compiler successful emit via a custom `writeFile` callback during `builder.emit()`.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```