### PR TITLE
perf(ng-packagr): prune rolldown cache payload and optimize file loader

### DIFF
--- a/src/lib/flatten/file-loader-plugin.ts
+++ b/src/lib/flatten/file-loader-plugin.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from 'node:path';
+import { dirname, extname, isAbsolute, resolve } from 'node:path';
 import type { Plugin } from 'rolldown';
 import { OutputFileCache } from '../ng-package/nodes';
 
@@ -6,43 +6,66 @@ import * as log from '../utils/log';
 import { ensureUnixPath } from '../utils/path';
 
 /**
- * A regex used to strip the file extension from a file path.
- */
-const FILE_EXT_REGEXP = /\.(c|m)?(t|j)s$/;
-
-/**
- * Loads a file and it's map.
+ * Loads a file and its map.
  */
 export function fileLoaderPlugin(fileCache: OutputFileCache, resolutionExtensions: string[], dtsMode: boolean): Plugin {
   return {
     name: 'file-loader',
     resolveId: function (id, importer) {
-      const normalizedId = ensureUnixPath(id);
-      if (fileCache.has(normalizedId)) {
-        return normalizedId;
+      let resolved: string;
+      if (importer) {
+        if (id[0] !== '.' && id[0] !== '/' && !isAbsolute(id)) {
+          return;
+        }
+
+        resolved = ensureUnixPath(resolve(dirname(importer), id));
+      } else {
+        resolved = ensureUnixPath(id);
       }
 
-      const potentialId = normalizedId.endsWith('.d.ts')
-        ? normalizedId
-        : normalizedId.replace(FILE_EXT_REGEXP, (_match, p1) => {
-            if (dtsMode) {
-              return p1 ? `.d.${p1}ts` : '.d.ts';
-            }
-
-            return p1 ? `.${p1}js` : '.js';
-          });
-
-      if (fileCache.has(potentialId)) {
-        return potentialId;
-      }
-
-      if (!importer) {
-        return;
-      }
-
-      const resolved = ensureUnixPath(resolve(dirname(importer), potentialId));
       if (fileCache.has(resolved)) {
         return resolved;
+      }
+
+      const ext = extname(resolved);
+      const base = resolved.slice(0, -ext.length);
+      if (dtsMode) {
+        let potential: string | undefined;
+        switch (ext) {
+          case '.js':
+          case '.ts':
+            potential = `${base}.d.ts`;
+            break;
+          case '.mjs':
+          case '.mts':
+            potential = `${base}.d.mts`;
+            break;
+          case '.cjs':
+          case '.cts':
+            potential = `${base}.d.cts`;
+            break;
+        }
+
+        if (potential && fileCache.has(potential)) {
+          return potential;
+        }
+      } else {
+        let potential: string | undefined;
+        switch (ext) {
+          case '.ts':
+            potential = `${base}.js`;
+            break;
+          case '.mts':
+            potential = `${base}.mjs`;
+            break;
+          case '.cts':
+            potential = `${base}.cjs`;
+            break;
+        }
+
+        if (potential && fileCache.has(potential)) {
+          return potential;
+        }
       }
 
       for (const suffix of resolutionExtensions) {

--- a/src/lib/flatten/rolldown.ts
+++ b/src/lib/flatten/rolldown.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 import { type OutputAsset, type OutputChunk, type RolldownPluginOption, rolldown } from 'rolldown';
 import { dts } from 'rolldown-plugin-dts';
 import { OutputFileCache } from '../ng-package/nodes';
@@ -89,14 +89,7 @@ export async function rolldownBundleFile(opts: RolldownOptions): Promise<{ files
   await bundle.close();
 
   return {
-    files: output.output.map(f => {
-      /** The map contents are in an asset file type, which makes storing the map in the cache as redudant. */
-      if (f.type === 'chunk') {
-        Object.defineProperty(f, 'map', { value: null, configurable: true });
-      }
-
-      return f;
-    }),
+    files: output.output,
   };
 }
 

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -1,5 +1,5 @@
+import { join } from 'node:path';
 import ora from 'ora';
-import { join } from 'path';
 import type { OutputAsset, OutputChunk } from 'rolldown';
 import { invalidateEntryPointsAndCacheOnFileChange } from '../../file-system/file-watcher';
 import { rolldownBundleFile } from '../../flatten/rolldown';
@@ -10,10 +10,22 @@ import { ensureUnixPath } from '../../utils/path';
 import { findEntryPointInProgress } from '../nodes';
 import { NgPackagrOptions } from '../options.di';
 
+type CachedBundleFile =
+  | {
+      type: 'chunk';
+      fileName: string;
+      code: string;
+    }
+  | {
+      type: 'asset';
+      fileName: string;
+      source: string | Uint8Array;
+    };
+
 interface BundlesCache {
   hash: string;
-  fesm2022: (OutputChunk | OutputAsset)[];
-  types: (OutputChunk | OutputAsset)[];
+  fesm2022: CachedBundleFile[];
+  types: CachedBundleFile[];
 }
 
 export const writeBundlesTransform = (options: NgPackagrOptions) =>
@@ -99,21 +111,34 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
         }),
       ]);
 
+      const mapFile = (file: OutputChunk | OutputAsset): CachedBundleFile =>
+        file.type === 'chunk'
+          ? {
+              type: 'chunk',
+              fileName: file.fileName,
+              code: file.code,
+            }
+          : {
+              type: 'asset',
+              fileName: file.fileName,
+              source: file.source,
+            };
+
       return {
         hash,
-        types: typesFiles,
-        fesm2022: fesmFiles,
+        types: typesFiles.map(mapFile),
+        fesm2022: fesmFiles.map(mapFile),
       };
     }
 
-    let cacheRollup: BundlesCache;
+    let bundlesCache: BundlesCache;
     try {
-      cacheRollup = await generateBundles();
-      spinner.succeed(`Generating FESM and DTS bundles`);
+      bundlesCache = await generateBundles();
+      spinner.succeed('Generating FESM and DTS bundles');
 
       // Invalidate dependent entry-points
       const changedDtsFiles: string[] = [];
-      for (const file of cacheRollup.types) {
+      for (const file of bundlesCache.types) {
         if (file.type !== 'chunk' || !file.fileName.endsWith('.d.ts')) {
           continue;
         }
@@ -134,6 +159,6 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
     }
 
     if (cacheDirectory) {
-      await saveCacheEntry(cacheDirectory, cacheKey, cacheRollup);
+      await saveCacheEntry(cacheDirectory, cacheKey, bundlesCache);
     }
   });


### PR DESCRIPTION
### Summary

- **Prune Rolldown Cache Payload**: Map `OutputChunk` and `OutputAsset` objects to store only `{ type, fileName, code, source }` before persisting to disk cache in `writeBundlesTransform`, avoiding disk I/O and memory overhead from serializing large AST graphs and module metadata.
- **Fast File Loader Path Resolution**: Avoid regex replacement closures on every import in `fileLoaderPlugin` by immediately bailing out on bare specifiers and using `extname` with direct path checks.
- **Avoid Chunk Mutating Overhead**: Return `output.output` directly from `rolldownBundleFile` since payload pruning in `writeBundlesTransform` removes the need to modify `OutputChunk.map`.