### PR TITLE
perf: consolidate component stylesheet bundling with shared load result cache

### DIFF
--- a/src/lib/styles/bundler-context.spec.ts
+++ b/src/lib/styles/bundler-context.spec.ts
@@ -1,0 +1,105 @@
+import { BundlerContext } from './bundler-context';
+import { MemoryLoadResultCache } from './load-result-cache';
+
+describe('BundlerContext', () => {
+  describe('invalidate', () => {
+    it('should return false when incremental is disabled', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ false, () => ({
+        entryPoints: ['main.js'],
+      }));
+      context.watchFiles.add('/workspace/src/app.css');
+
+      expect(context.invalidate(['/workspace/src/app.css'])).toBeFalse();
+    });
+
+    it('should return true when a watch file matches changed files as an array', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ true, () => ({
+        entryPoints: ['main.js'],
+      }));
+      context.watchFiles.add('/workspace/src/app.css');
+
+      expect(context.invalidate(['/workspace/src/app.css'])).toBeTrue();
+    });
+
+    it('should return true when a watch file matches changed files as a ReadonlySet', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ true, () => ({
+        entryPoints: ['main.js'],
+      }));
+      context.watchFiles.add('/workspace/src/app.css');
+
+      const changedSet: ReadonlySet<string> = new Set(['/workspace/src/app.css']);
+      expect(context.invalidate(changedSet)).toBeTrue();
+    });
+
+    it('should return false when changed files do not intersect with watchFiles', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ true, () => ({
+        entryPoints: ['main.js'],
+      }));
+      context.watchFiles.add('/workspace/src/app.css');
+
+      expect(context.invalidate(['/workspace/src/other.css'])).toBeFalse();
+    });
+
+    it('should correctly handle relative changed file paths', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ true, () => ({
+        entryPoints: ['main.js'],
+      }));
+      context.watchFiles.add('/workspace/src/app.css');
+
+      expect(context.invalidate(['src/app.css'])).toBeTrue();
+    });
+
+    it('should correctly handle relative paths inside a ReadonlySet', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ true, () => ({
+        entryPoints: ['main.js'],
+      }));
+      context.watchFiles.add('/workspace/src/app.css');
+
+      const set: ReadonlySet<string> = new Set(['src/app.css']);
+      expect(context.invalidate(set)).toBeTrue();
+    });
+
+    it('should invalidate shared load cache when files change', async () => {
+      const loadCache = new MemoryLoadResultCache();
+      await loadCache.put('file:/workspace/src/app.css', {
+        contents: 'body {}',
+        loader: 'css',
+        watchFiles: ['/workspace/src/app.css'],
+      });
+
+      const context = new BundlerContext(
+        '/workspace',
+        /* incremental */ true,
+        () => ({ entryPoints: ['main.js'] }),
+        /* useContext */ false,
+        /* initialFilter */ undefined,
+        loadCache,
+      );
+
+      expect(loadCache.get('file:/workspace/src/app.css')).toBeDefined();
+      expect(context.invalidate(['/workspace/src/app.css'])).toBeTrue();
+      expect(loadCache.get('file:/workspace/src/app.css')).toBeUndefined();
+    });
+
+    it('should work when watchFiles is smaller than changed files', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ true, () => ({
+        entryPoints: ['main.js'],
+      }));
+      context.watchFiles.add('/workspace/src/file10.css');
+
+      const changedFiles = Array.from({ length: 100 }, (_, i) => `/workspace/src/file${i}.css`);
+      expect(context.invalidate(new Set(changedFiles))).toBeTrue();
+    });
+
+    it('should work when changed files is smaller than watchFiles', () => {
+      const context = new BundlerContext('/workspace', /* incremental */ true, () => ({
+        entryPoints: ['main.js'],
+      }));
+      for (let i = 0; i < 100; i++) {
+        context.watchFiles.add(`/workspace/src/file${i}.css`);
+      }
+
+      expect(context.invalidate(new Set(['/workspace/src/file50.css']))).toBeTrue();
+    });
+  });
+});

--- a/src/lib/styles/bundler-context.ts
+++ b/src/lib/styles/bundler-context.ts
@@ -9,7 +9,8 @@ import {
   build,
   context,
 } from 'esbuild';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
+import { ensureUnixPath } from '../utils/path';
 import { LoadResultCache, MemoryLoadResultCache } from './load-result-cache';
 
 export type BundleContextResult =
@@ -65,14 +66,22 @@ export class BundlerContext {
   #disposed = false;
   #optionsFactory: BundlerOptionsFactory<BuildOptions & { metafile: true; write: false }>;
   #shouldCacheResult: boolean;
-  #loadCache?: MemoryLoadResultCache;
+  #loadCache?: LoadResultCache;
   readonly watchFiles: Set<string> = new Set<string>();
 
   constructor(
     private workspaceRoot: string,
     private incremental: boolean,
     options: BuildOptions | BundlerOptionsFactory,
+    private useContext = incremental,
+    initialFilter?: ((initial: Readonly<InitialFileRecord>) => boolean) | LoadResultCache,
+    sharedLoadCache?: LoadResultCache,
   ) {
+    if (initialFilter && typeof initialFilter !== 'function') {
+      this.#loadCache = initialFilter;
+    } else {
+      this.#loadCache = sharedLoadCache;
+    }
     // To cache the results an option factory is needed to capture the full set of dependencies
     this.#shouldCacheResult = incremental && typeof options === 'function';
     this.#optionsFactory = (...args) => {
@@ -123,7 +132,7 @@ export class BundlerContext {
   async #performBundle(): Promise<BundleContextResult> {
     // Create esbuild options if not present
     if (this.#esbuildOptions === undefined) {
-      if (this.incremental) {
+      if (this.incremental && !this.#loadCache) {
         this.#loadCache = new MemoryLoadResultCache();
       }
       this.#esbuildOptions = this.#optionsFactory(this.#loadCache);
@@ -138,7 +147,7 @@ export class BundlerContext {
       if (this.#esbuildContext) {
         // Rebuild using the existing incremental build context
         result = await this.#esbuildContext.rebuild();
-      } else if (this.incremental) {
+      } else if (this.useContext) {
         // Create an incremental build context and perform the first build.
         // Context creation does not perform a build.
         const esbuildContext = await context(this.#esbuildOptions);
@@ -150,28 +159,23 @@ export class BundlerContext {
         result = await this.#esbuildContext.rebuild();
       } else {
         // For non-incremental builds, perform a single build
+        if (this.#disposed) {
+          throw new Error('BundlerContext was disposed during build.');
+        }
         result = await build(this.#esbuildOptions);
+        if (this.#disposed) {
+          throw new Error('BundlerContext was disposed during build.');
+        }
       }
     } catch (failure) {
       // Build failures will throw an exception which contains errors/warnings
       if (isEsBuildFailure(failure)) {
         this.#addErrorsToWatch(failure);
+        this.#addLoadCacheFilesToWatch();
 
         return failure;
       } else {
         throw failure;
-      }
-    } finally {
-      if (this.incremental) {
-        // When incremental always add any files from the load result cache
-        if (this.#loadCache) {
-          for (const file of this.#loadCache.watchFiles) {
-            if (!isInternalAngularFile(file)) {
-              // watch files are fully resolved paths
-              this.watchFiles.add(file);
-            }
-          }
-        }
       }
     }
 
@@ -181,9 +185,30 @@ export class BundlerContext {
     if (this.incremental) {
       // Add input files except virtual angular files which do not exist on disk
       for (const input of Object.keys(result.metafile.inputs)) {
-        if (!isInternalAngularFile(input)) {
-          // input file paths are always relative to the workspace root
-          this.watchFiles.add(join(this.workspaceRoot, input));
+        const isInternal = isInternalAngularFile(input) || isInternalBundlerFile(input);
+
+        // Input file paths are always relative to the workspace root unless already absolute
+        const normalizedAbsoluteInput = isAbsolute(input)
+          ? ensureUnixPath(input)
+          : ensureUnixPath(join(this.workspaceRoot, input));
+
+        if (!isInternal) {
+          this.watchFiles.add(normalizedAbsoluteInput);
+        }
+
+        if (this.#loadCache) {
+          const cachedLoad = await (this.#loadCache.get(input) ??
+            this.#loadCache.get(input.replace(';', ':')) ??
+            this.#loadCache.get('file:' + normalizedAbsoluteInput));
+          if (cachedLoad?.watchFiles) {
+            for (const file of cachedLoad.watchFiles) {
+              if (!isInternalAngularFile(file)) {
+                this.watchFiles.add(
+                  isAbsolute(file) ? ensureUnixPath(file) : ensureUnixPath(join(this.workspaceRoot, file)),
+                );
+              }
+            }
+          }
         }
       }
     }
@@ -191,6 +216,7 @@ export class BundlerContext {
     // Return if the build encountered any errors
     if (result.errors.length) {
       this.#addErrorsToWatch(result);
+      this.#addLoadCacheFilesToWatch();
 
       return {
         errors: result.errors,
@@ -209,14 +235,26 @@ export class BundlerContext {
 
   #addErrorsToWatch(result: BuildFailure | BuildResult): void {
     for (const error of result.errors) {
-      let file = error.location?.file;
+      const file = error.location?.file;
       if (file && !isInternalAngularFile(file)) {
-        this.watchFiles.add(join(this.workspaceRoot, file));
+        this.watchFiles.add(isAbsolute(file) ? ensureUnixPath(file) : ensureUnixPath(join(this.workspaceRoot, file)));
       }
-      for (const note of error.notes) {
-        file = note.location?.file;
-        if (file && !isInternalAngularFile(file)) {
-          this.watchFiles.add(join(this.workspaceRoot, file));
+      for (const note of error.notes ?? []) {
+        const noteFile = note.location?.file;
+        if (noteFile && !isInternalAngularFile(noteFile)) {
+          this.watchFiles.add(
+            isAbsolute(noteFile) ? ensureUnixPath(noteFile) : ensureUnixPath(join(this.workspaceRoot, noteFile)),
+          );
+        }
+      }
+    }
+  }
+
+  #addLoadCacheFilesToWatch(): void {
+    if (this.incremental && this.#loadCache) {
+      for (const file of this.#loadCache.watchFiles) {
+        if (!isInternalAngularFile(file)) {
+          this.watchFiles.add(isAbsolute(file) ? ensureUnixPath(file) : ensureUnixPath(join(this.workspaceRoot, file)));
         }
       }
     }
@@ -229,19 +267,72 @@ export class BundlerContext {
    * to be stored.
    * @returns True, if the result was invalidated; False, otherwise.
    */
-  invalidate(files: Iterable<string>): boolean {
+  invalidate(files: Iterable<string> | ReadonlySet<string>): boolean {
     if (!this.incremental) {
       return false;
     }
 
-    let invalid = false;
-    for (const file of files) {
-      if (this.#loadCache?.invalidate(file)) {
-        invalid = true;
-        continue;
+    let candidateFiles: ReadonlySet<string>;
+    if (files instanceof Set) {
+      let isCandidateReady = true;
+      for (const file of files) {
+        if (
+          file !== ensureUnixPath(file) ||
+          (!isAbsolute(file) && !files.has(ensureUnixPath(join(this.workspaceRoot, file))))
+        ) {
+          isCandidateReady = false;
+          break;
+        }
       }
 
-      invalid ||= this.watchFiles.has(file);
+      if (isCandidateReady) {
+        candidateFiles = files;
+      } else {
+        const normalizedFiles = new Set<string>();
+        for (const file of files) {
+          const normalized = ensureUnixPath(file);
+          normalizedFiles.add(normalized);
+          if (!isAbsolute(normalized)) {
+            normalizedFiles.add(ensureUnixPath(join(this.workspaceRoot, normalized)));
+          }
+        }
+        candidateFiles = normalizedFiles;
+      }
+    } else {
+      const normalizedFiles = new Set<string>();
+      for (const file of files) {
+        const normalized = ensureUnixPath(file);
+        normalizedFiles.add(normalized);
+        if (!isAbsolute(normalized)) {
+          normalizedFiles.add(ensureUnixPath(join(this.workspaceRoot, normalized)));
+        }
+      }
+      candidateFiles = normalizedFiles;
+    }
+
+    let invalid = false;
+    for (const file of candidateFiles) {
+      if (this.#loadCache?.invalidate(file)) {
+        invalid = true;
+      }
+    }
+
+    if (!invalid) {
+      if (this.watchFiles.size < candidateFiles.size) {
+        for (const file of this.watchFiles) {
+          if (candidateFiles.has(file)) {
+            invalid = true;
+            break;
+          }
+        }
+      } else {
+        for (const file of candidateFiles) {
+          if (this.watchFiles.has(file)) {
+            invalid = true;
+            break;
+          }
+        }
+      }
     }
 
     if (invalid) {
@@ -270,6 +361,20 @@ export class BundlerContext {
   }
 }
 
-function isInternalAngularFile(file: string) {
+function isInternalAngularFile(file: string): boolean {
   return file.startsWith('angular:');
+}
+
+function isInternalBundlerFile(file: string): boolean {
+  // Bundler virtual files such as "<define:???>" or "<runtime>"
+  if (file[0] === '<' && file.at(-1) === '>') {
+    return true;
+  }
+
+  // Any (disabled): path is a virtual esbuild entry that doesn't exist on disk
+  if (file.includes('(disabled):')) {
+    return true;
+  }
+
+  return false;
 }

--- a/src/lib/styles/cache.spec.ts
+++ b/src/lib/styles/cache.spec.ts
@@ -133,4 +133,12 @@ describe('MemoryCache', () => {
     const val2 = await cache.getOrCreate('key', () => 'should-not-run');
     expect(val2).toBe('override-value');
   });
+
+  it('should delete a key from the cache', async () => {
+    await cache.put('key', 'value');
+    expect(await cache.get('key')).toBe('value');
+    expect(cache.delete('key')).toBeTrue();
+    expect(await cache.get('key')).toBeUndefined();
+    expect(cache.delete('key')).toBeFalse();
+  });
 });

--- a/src/lib/styles/cache.ts
+++ b/src/lib/styles/cache.ts
@@ -170,6 +170,15 @@ export class Cache<V, S extends CacheStore<V> = CacheStore<V>> {
   }
 
   /**
+   * Clears internal state for a specific namespaced key (requests, write counts, and pending gets).
+   */
+  protected deleteInternal(namespacedKey: string): void {
+    this.#requests.delete(namespacedKey);
+    this.#writeCounts.delete(namespacedKey);
+    this.#pendingGets.delete(namespacedKey);
+  }
+
+  /**
    * Clears the base class internal state (requests, write counts, and pending gets).
    */
   protected clearInternal(): void {
@@ -185,6 +194,18 @@ export class Cache<V, S extends CacheStore<V> = CacheStore<V>> {
 export class MemoryCache<V> extends Cache<V, Map<string, V>> {
   constructor() {
     super(new Map());
+  }
+
+  /**
+   * Removes the specified key from the cache instance.
+   * @param key The key to remove.
+   * @returns True if an element in the Map existed and has been removed, or false if the element does not exist.
+   */
+  delete(key: string): boolean {
+    const namespacedKey = this.withNamespace(key);
+    this.deleteInternal(namespacedKey);
+
+    return this.store.delete(namespacedKey);
   }
 
   /**

--- a/src/lib/styles/component-stylesheets.ts
+++ b/src/lib/styles/component-stylesheets.ts
@@ -1,8 +1,10 @@
 import { Message, Metafile, OutputFile } from 'esbuild';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
+import { ensureUnixPath } from '../utils/path';
 import { BuildOutputFileType, BundleContextResult, BundlerContext } from './bundler-context';
 import { MemoryCache } from './cache';
+import { MemoryLoadResultCache } from './load-result-cache';
 import { BundleStylesheetOptions, createStylesheetBundleOptions } from './stylesheets/bundle-options';
 import { shutdownSassWorkerPool } from './stylesheets/sass-language';
 
@@ -23,11 +25,12 @@ export interface ComponentStylesheetResult {
 export class ComponentStylesheetBundler {
   readonly #fileContexts = new MemoryCache<BundlerContext>();
   readonly #inlineContexts = new MemoryCache<BundlerContext>();
+  readonly #loadCache = new MemoryLoadResultCache();
 
   /**
-   *
    * @param options An object containing the stylesheet bundling options.
-   * @param cache A load result cache to use when bundling.
+   * @param defaultInlineLanguage The default language to use for inline component styles.
+   * @param incremental True if incremental watch mode is enabled.
    */
   constructor(
     private readonly options: BundleStylesheetOptions,
@@ -36,20 +39,35 @@ export class ComponentStylesheetBundler {
   ) {}
 
   async bundleFile(entry: string): Promise<ComponentStylesheetResult> {
+    entry = ensureUnixPath(entry);
+
     const bundlerContext = await this.#fileContexts.getOrCreate(entry, () => {
-      return new BundlerContext(this.options.workspaceRoot, this.incremental, loadCache => {
-        const buildOptions = createStylesheetBundleOptions(this.options, loadCache);
+      return new BundlerContext(
+        this.options.workspaceRoot,
+        this.incremental,
+        loadCache => {
+          const buildOptions = createStylesheetBundleOptions(this.options, loadCache);
 
-        buildOptions.entryPoints = [entry];
+          buildOptions.entryPoints = [entry];
 
-        return buildOptions;
-      });
+          return buildOptions;
+        },
+        /* useContext */ false,
+        /* initialFilter */ undefined,
+        this.#loadCache,
+      );
     });
 
     return this.extractResult(await bundlerContext.bundle(), bundlerContext.watchFiles);
   }
 
-  async bundleInline(data: string, filename: string, language: string = this.defaultInlineLanguage): Promise<ComponentStylesheetResult> {
+  async bundleInline(
+    data: string,
+    filename: string,
+    language: string = this.defaultInlineLanguage,
+  ): Promise<ComponentStylesheetResult> {
+    filename = ensureUnixPath(filename);
+
     // Use a hash of the inline stylesheet content to ensure a consistent identifier. External stylesheets will resolve
     // to the actual stylesheet file path.
     // TODO: Consider xxhash instead for hashing
@@ -59,37 +77,44 @@ export class ComponentStylesheetBundler {
     const bundlerContext = await this.#inlineContexts.getOrCreate(entry, () => {
       const namespace = 'angular:styles/component';
 
-      return new BundlerContext(this.options.workspaceRoot, this.incremental, loadCache => {
-        const buildOptions = createStylesheetBundleOptions(this.options, loadCache, {
-          [entry]: data,
-        });
-        buildOptions.entryPoints = [`${namespace};${entry}`];
+      return new BundlerContext(
+        this.options.workspaceRoot,
+        this.incremental,
+        loadCache => {
+          const buildOptions = createStylesheetBundleOptions(this.options, loadCache, {
+            [entry]: data,
+          });
+          buildOptions.entryPoints = [`${namespace};${entry}`];
 
-        buildOptions.plugins.push({
-          name: 'angular-component-styles',
-          setup(build) {
-            build.onResolve({ filter: /^angular:styles\/component;/ }, args => {
-              if (args.kind !== 'entry-point') {
-                return null;
-              }
+          buildOptions.plugins.push({
+            name: 'angular-component-styles',
+            setup(build) {
+              build.onResolve({ filter: /^angular:styles\/component;/ }, args => {
+                if (args.kind !== 'entry-point') {
+                  return null;
+                }
 
-              return {
-                path: entry,
-                namespace,
-              };
-            });
-            build.onLoad({ filter: /^css;/, namespace }, () => {
-              return {
-                contents: data,
-                loader: 'css',
-                resolveDir: path.dirname(filename),
-              };
-            });
-          },
-        });
+                return {
+                  path: entry,
+                  namespace,
+                };
+              });
+              build.onLoad({ filter: /^css;/, namespace }, () => {
+                return {
+                  contents: data,
+                  loader: 'css',
+                  resolveDir: path.dirname(filename),
+                };
+              });
+            },
+          });
 
-        return buildOptions;
-      });
+          return buildOptions;
+        },
+        /* useContext */ false,
+        /* initialFilter */ undefined,
+        this.#loadCache,
+      );
     });
 
     // Extract the result of the bundling from the output files
@@ -101,12 +126,20 @@ export class ComponentStylesheetBundler {
    * @param files The group of files that have been modified
    * @returns An array of file based stylesheet entries if any were invalidated; otherwise, undefined.
    */
-  invalidate(files: Iterable<string>): string[] | undefined {
+  invalidate(files: Iterable<string> | ReadonlySet<string>): string[] | undefined {
     if (!this.incremental) {
       return;
     }
 
-    const normalizedFiles = [...files].map(path.normalize);
+    const normalizedFiles = new Set<string>();
+    for (const file of files) {
+      const normalized = ensureUnixPath(file);
+      normalizedFiles.add(normalized);
+      if (!path.isAbsolute(normalized)) {
+        normalizedFiles.add(ensureUnixPath(path.join(this.options.workspaceRoot, normalized)));
+      }
+    }
+
     let entries: string[] | undefined;
 
     for (const [entry, bundler] of this.#fileContexts.entries()) {
@@ -115,8 +148,17 @@ export class ComponentStylesheetBundler {
         entries.push(entry);
       }
     }
-    for (const bundler of this.#inlineContexts.values()) {
-      bundler.invalidate(normalizedFiles);
+    for (const [entry, bundler] of this.#inlineContexts.entries()) {
+      // Entry is format: [language, id, filename].join(';')
+      const firstSemi = entry.indexOf(';');
+      const secondSemi = firstSemi !== -1 ? entry.indexOf(';', firstSemi + 1) : -1;
+      const filename = secondSemi !== -1 ? entry.slice(secondSemi + 1) : '';
+      if (filename && normalizedFiles.has(ensureUnixPath(filename))) {
+        this.#inlineContexts.delete(entry);
+        void bundler.dispose();
+      } else {
+        bundler.invalidate(normalizedFiles);
+      }
     }
 
     return entries;
@@ -126,11 +168,15 @@ export class ComponentStylesheetBundler {
     const contexts = [...this.#fileContexts.values(), ...this.#inlineContexts.values()];
     this.#fileContexts.clear();
     this.#inlineContexts.clear();
+    this.#loadCache.clear();
 
     await Promise.allSettled([shutdownSassWorkerPool(), ...contexts.map(context => context.dispose())]);
   }
 
-  private extractResult(result: BundleContextResult, referencedFiles: Set<string> | undefined): ComponentStylesheetResult {
+  private extractResult(
+    result: BundleContextResult,
+    referencedFiles: Set<string> | undefined,
+  ): ComponentStylesheetResult {
     let contents = '';
     let metafile;
     const outputFiles: OutputFile[] = [];

--- a/src/lib/styles/load-result-cache.ts
+++ b/src/lib/styles/load-result-cache.ts
@@ -1,9 +1,10 @@
 import type { OnLoadResult, PluginBuild } from 'esbuild';
-import { normalize } from 'node:path';
+import { ensureUnixPath } from '../utils/path';
 
 export interface LoadResultCache {
   get(path: string): OnLoadResult | undefined;
   put(path: string, result: OnLoadResult): Promise<void>;
+  invalidate(path: string): boolean;
   readonly watchFiles: ReadonlyArray<string>;
 }
 
@@ -15,7 +16,7 @@ export function createCachedLoad(
     return callback;
   }
 
-  return async (args) => {
+  return async args => {
     const loadCacheKey = `${args.namespace}:${args.path}`;
     let result: OnLoadResult | null | undefined = cache.get(loadCacheKey);
 
@@ -50,7 +51,7 @@ export class MemoryLoadResultCache implements LoadResultCache {
     if (result.watchFiles) {
       for (const watchFile of result.watchFiles) {
         // Normalize the watch file path to ensure OS consistent paths
-        const normalizedWatchFile = normalize(watchFile);
+        const normalizedWatchFile = ensureUnixPath(watchFile);
         let affected = this.#fileDependencies.get(normalizedWatchFile);
         if (affected === undefined) {
           affected = new Set();
@@ -62,7 +63,7 @@ export class MemoryLoadResultCache implements LoadResultCache {
   }
 
   invalidate(path: string): boolean {
-    const affectedPaths = this.#fileDependencies.get(path);
+    const affectedPaths = this.#fileDependencies.get(ensureUnixPath(path));
     let found = false;
 
     if (affectedPaths) {
@@ -81,5 +82,10 @@ export class MemoryLoadResultCache implements LoadResultCache {
     // this.#loadResults.keys() is not included here because the keys
     // are namespaced request paths and not disk-based file paths.
     return [...this.#fileDependencies.keys()];
+  }
+
+  clear(): void {
+    this.#loadResults.clear();
+    this.#fileDependencies.clear();
   }
 }


### PR DESCRIPTION
Port angular/angular-cli#33906 to ng-packagr.

Replaces per-stylesheet `esbuild.context` proliferation in `ComponentStylesheetBundler` with ephemeral single-shot `esbuild.build()` invocations and a shared, persistent `MemoryLoadResultCache`.

1. Eliminates Go process IPC context proliferation.
2. Cross-component Sass partial & preprocessor cache sharing via unified `MemoryLoadResultCache`.
3. In-flight compilation deduplication coalescing concurrent requests.
4. Optimized set intersection invalidation (O(min(|A|, |B|))) accelerating large-scale file invalidations.