### PR TITLE
perf(ng-packagr): share sass directory and resolution caches across stylesheets

### DIFF
--- a/src/lib/styles/component-stylesheets.ts
+++ b/src/lib/styles/component-stylesheets.ts
@@ -6,7 +6,7 @@ import { BuildOutputFileType, BundleContextResult, BundlerContext } from './bund
 import { MemoryCache } from './cache';
 import { MemoryLoadResultCache } from './load-result-cache';
 import { BundleStylesheetOptions, createStylesheetBundleOptions } from './stylesheets/bundle-options';
-import { shutdownSassWorkerPool } from './stylesheets/sass-language';
+import { resetSassWorkerPoolCaches, shutdownSassWorkerPool } from './stylesheets/sass-language';
 
 export interface ComponentStylesheetResult {
   errors: Message[] | undefined;
@@ -130,6 +130,8 @@ export class ComponentStylesheetBundler {
     if (!this.incremental) {
       return;
     }
+
+    resetSassWorkerPoolCaches();
 
     const normalizedFiles = new Set<string>();
     for (const file of files) {

--- a/src/lib/styles/sass/sass-service.ts
+++ b/src/lib/styles/sass/sass-service.ts
@@ -52,6 +52,7 @@ export const useSassEmbedded =
 export class SassCompiler {
   #asyncCompiler: AsyncCompiler | undefined;
   #asyncCompilerPromise: Promise<AsyncCompiler> | undefined;
+  readonly #directoryCache = new Map<string, DirectoryEntry>();
 
   constructor(private readonly rebase = false) {}
 
@@ -122,7 +123,7 @@ export class SassCompiler {
     let finalImporters: (Importer<'async'> | FileImporter<'async'> | NodePackageImporter)[] | undefined;
     let loadPaths = options.loadPaths;
     const entryDirectory = url ? dirname(fileURLToPath(url)) : process.cwd();
-    const directoryCache = new Map<string, DirectoryEntry>();
+    const directoryCache = this.#directoryCache;
     const rebaseSourceMaps = options.sourceMap ? new Map<string, RawSourceMap>() : undefined;
 
     if (importers?.length) {
@@ -175,10 +176,19 @@ export class SassCompiler {
   }
 
   /**
+   * Clear the directory cache.
+   */
+  clearCache(): void {
+    this.#directoryCache.clear();
+  }
+
+  /**
    * Shutdown the Sass compiler.
    * @returns A void promise that resolves when closing is complete.
    */
   async close(): Promise<void> {
+    this.clearCache();
+
     if (this.#asyncCompilerPromise !== undefined) {
       try {
         await this.#ensureAsyncCompiler();

--- a/src/lib/styles/stylesheets/sass-language.ts
+++ b/src/lib/styles/stylesheets/sass-language.ts
@@ -8,12 +8,25 @@ import { StylesheetLanguage, StylesheetPluginOptions } from './stylesheet-plugin
 
 let sassService: SassCompiler | undefined;
 let sassServicePromise: Promise<SassCompiler> | undefined;
+let resolutionCache: MemoryCache<URL | null> | undefined;
+let packageRootCache: MemoryCache<string | null> | undefined;
 
 function isSassException(error: unknown): error is Exception {
   return !!error && typeof error === 'object' && 'sassMessage' in error;
 }
 
+export function resetSassWorkerPoolCaches(): void {
+  resolutionCache?.clear();
+  packageRootCache?.clear();
+  if (sassService) {
+    sassService.clearCache();
+  } else if (sassServicePromise !== undefined) {
+    void sassServicePromise.then(service => service.clearCache());
+  }
+}
+
 export function shutdownSassWorkerPool(): void {
+  resetSassWorkerPoolCaches();
   if (sassService) {
     void sassService.close();
     sassService = undefined;
@@ -81,14 +94,15 @@ async function compileString(
     }
   }
 
-  // Cache is currently local to individual compile requests.
-  // Caching follows Sass behavior where a given url will always resolve to the same value
-  // regardless of its importer's path.
+  // Caching follows Sass behavior where a given package url will always resolve to the same value
+  // regardless of its importer's path. Relative paths are qualified with the containing URL.
   // A null value indicates that the cached resolution attempt failed to find a location and
   // later stage resolution should be attempted. This avoids potentially expensive repeat
   // failing resolution attempts.
-  const resolutionCache = new MemoryCache<URL | null>();
-  const packageRootCache = new MemoryCache<string | null>();
+  resolutionCache ??= new MemoryCache<URL | null>();
+  packageRootCache ??= new MemoryCache<string | null>();
+  const currentResolutionCache = resolutionCache;
+  const currentPackageRootCache = packageRootCache;
   const warnings: PartialMessage[] = [];
   const { silenceDeprecations, futureDeprecations, fatalDeprecations } = options.sass ?? {};
 
@@ -106,8 +120,10 @@ async function compileString(
       quietDeps: true,
       importers: [
         {
-          findFileUrl: (url, options) =>
-            resolutionCache.getOrCreate(url, async () => {
+          findFileUrl: (url, options) => {
+            const cacheKey = url.startsWith('pkg:') ? url : `${options.containingUrl?.href ?? ''}:${url}`;
+
+            return currentResolutionCache.getOrCreate(cacheKey, async () => {
               const result = await resolveUrl(url, options);
               if (result.path) {
                 return pathToFileURL(result.path);
@@ -118,7 +134,8 @@ async function compileString(
 
               // Caching package root locations is particularly beneficial for `@material/*` packages
               // which extensively use deep imports.
-              const packageRoot = await packageRootCache.getOrCreate(packageName, async () => {
+              const packageRootKey = `${options.containingUrl?.href ?? ''}:${packageName}`;
+              const packageRoot = await currentPackageRootCache.getOrCreate(packageRootKey, async () => {
                 // Use the required presence of a package root `package.json` file to resolve the location
                 const packageResult = await resolveUrl(packageName + '/package.json', options);
 
@@ -135,7 +152,8 @@ async function compileString(
 
               // Not found
               return null;
-            }),
+            });
+          },
         },
       ],
       logger: {


### PR DESCRIPTION
Port angular/angular-cli#34041 to ng-packagr.

Previously, Sass resolution caches (`resolutionCache` and `packageRootCache`) in `sass-language.ts` and the filesystem directory entry cache (`directoryCache`) in `sass-service.ts` were created anew for every individual stylesheet compilation request.

When compiling libraries that use component styles importing shared design tokens or library stylesheets (such as `@angular/material` or deep-imported `@material/*` packages), rebasing importers repeatedly invoked synchronous `fs.readdirSync` across the same node module package directories, and re-executed esbuild resolution calls.

To eliminate redundant disk I/O and resolution overhead:
- Hoist `directoryCache` to an instance property of `SassCompiler`, persisting directory listings across compile calls and clearing them upon compiler shutdown in `close()` or `clearCache()`.
- Hoist `resolutionCache` and `packageRootCache` to module-scoped caches in `sass-language.ts`, clearing them via `resetSassWorkerPoolCaches()` during `shutdownSassWorkerPool()` or when invalidating component stylesheets.
- Contextualize relative import resolution cache keys and package root cache keys using the containing URL to preserve correctness while allowing package specifiers to resolve once across all stylesheets.