### PR TITLE
docs: clarify asset handling in secondary entry points

### DIFF
--- a/docs/copy-assets.md
+++ b/docs/copy-assets.md
@@ -24,13 +24,27 @@ You can copy these assets by using the `assets` option in ng-package.json.
 
 Note that the advanced asset pattern, with a same syntax as Angular Builder's one, is used for SCSS files in the example above to allow a different output dir, so that we can put our styles under `projects/my-lib/src/styles` instead of `projects/my-lib/styles`.
 
+## Secondary Entry Points
+
+The `assets` option is only valid in the primary (root) `ng-package.json`. Secondary entry point `ng-package.json` files do not support the `assets` option.
+
+To distribute assets destined for a secondary entry point, define them in the primary `ng-package.json` using the object syntax and specify the secondary entry point's subfolder in the `output` property:
+
+```json
+{
+  "$schema": "...",
+  "assets": [{ "input": "src/testing/assets", "glob": "**/*", "output": "testing/assets" }]
+}
+```
 
 ## Exporting Styles
+
 When including additional assets like Sass mixins or pre-compiled CSS, you need to add these manually to the conditional "exports" in the `package.json` of the primary entry point.
 
 ng-packagr will merge the manually-added "exports" with auto-generated ones, allowing for library authors to configure additional export sub-paths, or custom conditions.
 
 ### Example package.json
+
 ```json
 {
   "name": "your-library",

--- a/docs/secondary-entrypoints.md
+++ b/docs/secondary-entrypoints.md
@@ -31,3 +31,16 @@ The contents of `my_package/testing/ng-package.json` can be as simple as:
 No, that is not a typo. No name is required. No version is required.
 It's all handled for you by ng-packagr!
 When built, the primary entry point is imported by `import {..} from '@my/library'` and the secondary entry point with `import {..} from '@my/library/testing'`.
+
+## Assets in Secondary Entry Points
+
+Secondary entry point `ng-package.json` files only configure entry-point-specific compilation options under the `lib` property (such as `entryFile`, `cssUrl`, `styleIncludePaths`, and `sass`). The `assets` option is not supported in secondary entry point configuration.
+
+To copy assets for a secondary entry point, configure them in the primary (root) `ng-package.json` using an asset object that specifies the secondary entry point's folder in the `output` property:
+
+```json
+{
+  "$schema": "...",
+  "assets": [{ "input": "src/testing/assets", "glob": "**/*", "output": "testing/assets" }]
+}
+```


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

The `assets` option is only supported in the primary (root) `ng-package.json`. Secondary entry point `ng-package.json` files do not support configuring assets.

This updates both `docs/copy-assets.md` and `docs/secondary-entrypoints.md` to clarify that assets for secondary entry points should be configured in the primary `ng-package.json` using an asset pattern object with an `output` property directed to the secondary entry point's folder.

Closes #2748

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```