### PR TITLE
perf(ng-packagr): configure rolldown dtsInput and skip dts annotation scanning

### DIFF
--- a/src/lib/flatten/rolldown.ts
+++ b/src/lib/flatten/rolldown.ts
@@ -31,7 +31,7 @@ export async function rolldownBundleFile(opts: RolldownOptions): Promise<{ files
     outExtension = '.d.ts';
     plugins = [
       fileLoaderPlugin(opts.fileCache, ['.d.ts', '/index.d.ts'], dtsMode),
-      dts({ generator: 'oxc', sourcemap: opts.sourcemap }),
+      dts({ dtsInput: true, tsconfig: false, generator: 'oxc', sourcemap: opts.sourcemap }),
     ];
   } else {
     outExtension = '.mjs';
@@ -80,7 +80,7 @@ export async function rolldownBundleFile(opts: RolldownOptions): Promise<{ files
     sourcemap: opts.sourcemap,
     comments: {
       legal: true,
-      annotation: true,
+      annotation: !dtsMode,
       jsdoc: dtsMode,
     },
   });


### PR DESCRIPTION
## Description

This PR optimizes Rolldown DTS bundle generation by configuring `dtsInput: true` and `tsconfig: false` in `rolldown-plugin-dts`, and skipping pure comment annotation scanning on declaration bundles.

### Background & Bottleneck

During DTS bundle generation, `ng-packagr` bundles pre-compiled `.d.ts` files from its in-memory file cache using `rolldown-plugin-dts`.

Previously:
1. **Unneeded Generator Hooks**: Without `dtsInput: true`, `rolldown-plugin-dts` installed `createGeneratePlugin`, which registers unnecessary lifecycle hooks (`buildStart`, `resolveId`, `transform`, `load`) intended for generating declarations from TypeScript source files, even though the inputs to `rolldownBundleFile` are already emitted `.d.ts` files.
2. **Synchronous Disk I/O for `tsconfig.json`**: Without `tsconfig: false`, the plugin performed synchronous directory walks and file reads looking for `tsconfig.json` via `get-tsconfig` on every DTS bundle invocation.
3. **Pure Annotation Scanning**: `comments.annotation: true` forced Oxc/Rolldown to scan all comment blocks in `.d.ts` files for tree-shaking hints (`/* #__PURE__ */`, `@__NO_SIDE_EFFECTS__`), which have no semantic meaning in declaration files.

### Changes in this PR

- Pass `{ dtsInput: true, tsconfig: false, generator: 'oxc', sourcemap: opts.sourcemap }` to `dts()`.
  - `dtsInput: true` tells `rolldown-plugin-dts` that input files are already declaration files, replacing `createGeneratePlugin` with the lightweight `createDtsInputPlugin`.
  - `tsconfig: false` skips searching for and parsing `tsconfig.json` from disk.
  - `generator: 'oxc'` prevents defaulting to `require('typescript')` or `tsgo` during options resolution.
- Set `comments.annotation: !dtsMode` so that pure annotation scanning is skipped for declaration files while preserved for JavaScript bundles (`.mjs`).

### Impact

- Eliminates synchronous disk I/O and JSON parsing for `tsconfig.json` on each entry point.
- Avoids redundant NAPI bridge hook invocations across declaration files.
- Reduces comment scanning and rendering overhead on large declaration bundles.