### PR TITLE
perf(ng-packagr): decouple sass daemon lifecycle from entry points

### DIFF
--- a/src/lib/ng-package/package.transform.ts
+++ b/src/lib/ng-package/package.transform.ts
@@ -25,6 +25,7 @@ import { createFileWatch, invalidateEntryPointsAndCacheOnFileChange } from '../f
 import { BuildGraph } from '../graph/build-graph';
 import { Node, STATE_DONE, STATE_ERROR, STATE_IN_PROGRESS, STATE_PENDING } from '../graph/node';
 import { Transform } from '../graph/transform';
+import { shutdownSassWorkerPool } from '../styles/stylesheets/sass-language';
 import { colors } from '../utils/color';
 import { rmdir } from '../utils/fs';
 import * as log from '../utils/log';
@@ -113,9 +114,10 @@ export const packageTransformFactory =
       finalize(() => {
         for (const node of ngPkg.dependents) {
           if (node instanceof EntryPointNode) {
-            node.cache.stylesheetProcessor?.destroy();
+            node.cache?.stylesheetProcessor?.destroy();
           }
         }
+        shutdownSassWorkerPool();
       }),
     );
   };

--- a/src/lib/styles/component-stylesheets.ts
+++ b/src/lib/styles/component-stylesheets.ts
@@ -6,7 +6,7 @@ import { BuildOutputFileType, BundleContextResult, BundlerContext } from './bund
 import { MemoryCache } from './cache';
 import { MemoryLoadResultCache } from './load-result-cache';
 import { BundleStylesheetOptions, createStylesheetBundleOptions } from './stylesheets/bundle-options';
-import { resetSassWorkerPoolCaches, shutdownSassWorkerPool } from './stylesheets/sass-language';
+import { resetSassWorkerPoolCaches } from './stylesheets/sass-language';
 
 export interface ComponentStylesheetResult {
   errors: Message[] | undefined;
@@ -172,7 +172,7 @@ export class ComponentStylesheetBundler {
     this.#inlineContexts.clear();
     this.#loadCache.clear();
 
-    await Promise.allSettled([shutdownSassWorkerPool(), ...contexts.map(context => context.dispose())]);
+    await Promise.allSettled(contexts.map(context => context.dispose()));
   }
 
   private extractResult(


### PR DESCRIPTION
### Summary
Currently, whenever an entry point finishes compilation, its stylesheet processor is destroyed via `finally { stylesheetProcessor?.destroy(); }` in `compile-ngc.transform.ts`. This invokes `ComponentStylesheetBundler.dispose()`, which in turn invoked `shutdownSassWorkerPool()`.

Shutting down the worker pool repeatedly kills the underlying `sass-embedded` Dart VM daemon process, forcing subsequent entry points to pay the process startup and warm-up latency cost (100–300ms) again.

This PR decouples the shared Sass worker pool daemon shutdown from the individual entry point bundler disposal:
- Removes `shutdownSassWorkerPool()` from `ComponentStylesheetBundler.dispose()` (only disposes the entry point's esbuild contexts).
- Invokes `shutdownSassWorkerPool()` in `packageTransformFactory`'s `finalize()` hook when package compilation completes.
- In watch mode, incremental stylesheet cache invalidation still triggers `resetSassWorkerPoolCaches()` as before.