### PR TITLE
perf(ng-packagr): disable rolldown circular dependency checks

### DIFF
--- a/src/lib/flatten/rolldown.ts
+++ b/src/lib/flatten/rolldown.ts
@@ -44,6 +44,9 @@ export async function rolldownBundleFile(opts: RolldownOptions): Promise<{ files
     external: (moduleId, parentId) => isExternalDependency(moduleId, parentId, jail),
     input: opts.entry,
     plugins,
+    checks: {
+      circularDependency: false,
+    },
     onwarn: warning => {
       switch (warning.code) {
         case 'CIRCULAR_DEPENDENCY':


### PR DESCRIPTION
### Summary
In `src/lib/flatten/rolldown.ts`, `CIRCULAR_DEPENDENCY` warnings are already filtered and ignored in the `onwarn` handler. However, leaving the check enabled causes Rolldown's Rust engine to traverse the module dependency graph to detect circular dependencies on every bundle invocation.

By configuring `checks: { circularDependency: false }`, Rolldown skips this graph traversal entirely, speeding up module bundling.