### PR TITLE
perf(ng-packagr): enable stylesheet bundler context caching in non-watch mode

### DIFF
--- a/src/lib/styles/bundler-context.ts
+++ b/src/lib/styles/bundler-context.ts
@@ -83,7 +83,7 @@ export class BundlerContext {
       this.#loadCache = sharedLoadCache;
     }
     // To cache the results an option factory is needed to capture the full set of dependencies
-    this.#shouldCacheResult = incremental && typeof options === 'function';
+    this.#shouldCacheResult = typeof options === 'function';
     this.#optionsFactory = (...args) => {
       const baseOptions = typeof options === 'function' ? options(...args) : options;
 


### PR DESCRIPTION
### Summary
In `src/lib/styles/bundler-context.ts`, `#shouldCacheResult` previously required both `incremental` (watch mode) and `typeof options === 'function'`:
```typescript
this.#shouldCacheResult = incremental && typeof options === 'function';
```

However, within non-watch builds, multiple Angular components within an entry point or across entry points frequently reference identical stylesheets (e.g. shared theme files, common component style mixes). Whenever an `options` factory is provided, the full set of dependencies is tracked and safe to cache.

This PR relaxes the requirement to `typeof options === 'function'`, allowing cold non-watch builds to reuse cached bundle results when identical stylesheets are processed.