### PR TITLE
perf(ng-packagr): parallelize package discovery and optimize config reads

### DIFF
--- a/src/lib/ng-package/discover-packages.ts
+++ b/src/lib/ng-package/discover-packages.ts
@@ -17,18 +17,35 @@ interface UserPackage {
   basePath: string;
 }
 
-async function readConfigFile(filePath: string): Promise<any> {
-  if (!(await exists(filePath))) {
-    return undefined;
+function parseJsonConfig(content: string): any {
+  const sanitized = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+  try {
+    return JSON.parse(sanitized);
+  } catch {
+    return parseJson(sanitized, undefined, { allowTrailingComma: true });
   }
+}
 
+async function readConfigFile(filePath: string): Promise<any> {
   if (filePath.endsWith('.js')) {
+    if (!(await exists(filePath))) {
+      return undefined;
+    }
+
     return import(filePath);
   }
 
-  const data = await readFile(filePath, 'utf-8');
+  let data: string;
+  try {
+    data = await readFile(filePath, 'utf-8');
+  } catch (err: unknown) {
+    if (typeof err === 'object' && err !== null && 'code' in err && (err as { code?: string }).code === 'ENOENT') {
+      return undefined;
+    }
+    throw err;
+  }
 
-  return parseJson(data, undefined, { allowTrailingComma: true });
+  return parseJsonConfig(data);
 }
 
 /**
@@ -141,10 +158,10 @@ export async function discoverPackages({ project }: { project: string }): Promis
   log.debug(`Found primary entry point: ${primary.moduleId}`);
 
   const folderPaths = await findSecondaryPackagesPaths(basePath, primary.$get('dest'));
+  const secondaryPackages = await Promise.all(folderPaths.map(folderPath => resolveUserPackage(folderPath, true)));
   const secondaries: NgEntryPoint[] = [];
 
-  for (const folderPath of folderPaths) {
-    const secondaryPackage = await resolveUserPackage(folderPath, true);
+  for (const secondaryPackage of secondaryPackages) {
     if (secondaryPackage) {
       secondaries.push(secondaryEntryPoint(primary, secondaryPackage));
     }

--- a/src/lib/utils/fs.ts
+++ b/src/lib/utils/fs.ts
@@ -16,9 +16,7 @@ export async function exists(path: PathLike): Promise<boolean> {
 
 export async function copyFile(src: string, dest: string): Promise<void> {
   const dir = dirname(dest);
-  if (!(await exists(dir))) {
-    await mkdir(dir, { recursive: true });
-  }
+  await mkdir(dir, { recursive: true });
 
   await cpFile(src, dest, constants.COPYFILE_FICLONE);
 }


### PR DESCRIPTION
### Summary
1. **Parallel Secondary Discovery**: Resolves secondary packages in parallel via `Promise.all(folderPaths.map(...))` instead of sequential `for..of` iteration.
2. **Direct File Reads (EAFP)**: In `readConfigFile`, attempts reading files directly and handles `ENOENT`, avoiding pre-flight `exists()` filesystem checks.
3. **Fast-Path JSON Parsing**: In `parseJsonConfig`, strips UTF-8 BOM (`0xFEFF`) and invokes native `JSON.parse`, falling back to `jsonc-parser` only on syntax errors.
4. **Direct `mkdir`**: Removes redundant `exists(dir)` check before `mkdir(dir, { recursive: true })` in `copyFile`.