### PR TITLE
perf(ng-packagr): optimize program versioning with fast 64-bit hashing

### DIFF
--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -212,17 +212,24 @@ export function cacheCompilerHost(
   };
 }
 
+function hash64(str: string): string {
+  let h1 = 0xdeadbeef ^ 0;
+  let h2 = 0x41c6ce57 ^ 0;
+  for (let i = 0, len = str.length; i < len; i++) {
+    const ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return (h1 >>> 0).toString(16).padStart(8, '0') + (h2 >>> 0).toString(16).padStart(8, '0');
+}
+
 export function augmentProgramWithVersioning(program: ts.Program): void {
-  const baseGetSourceFiles = program.getSourceFiles;
-  program.getSourceFiles = function (...parameters) {
-    const files: readonly (ts.SourceFile & { version?: string })[] = baseGetSourceFiles(...parameters);
-
-    for (const file of files) {
-      if (file.version === undefined) {
-        file.version = createHash('sha256').update(file.text).digest('hex');
-      }
+  for (const file of program.getSourceFiles() as readonly (ts.SourceFile & { version?: string })[]) {
+    if (file.version === undefined) {
+      file.version = hash64(file.text);
     }
-
-    return files;
-  };
+  }
 }


### PR DESCRIPTION
### Summary
1. **Remove `getSourceFiles` Monkey-Patching**: In `augmentProgramWithVersioning`, instead of wrapping `program.getSourceFiles` with a dynamic interceptor that re-iterates every source file on each call across diagnostics and emit, execute a single one-time pass over `program.getSourceFiles()` on program creation.
2. **Fast 64-Bit Non-Cryptographic Hashing**: Replace the cryptographic SHA-256 hash (`createHash('sha256')`) with a fast 64-bit non-cryptographic integer hash to compute `SourceFile.version`.