### PR TITLE
perf(ng-packagr): implement parallel dag scheduling for entry points

### DIFF
--- a/src/lib/graph/build-graph.ts
+++ b/src/lib/graph/build-graph.ts
@@ -25,10 +25,22 @@ export interface Traversable<T> {
  * Technically, it's implemented as a map-like collection with references between map entries.
  */
 export class BuildGraph implements Traversable<Node> {
-  private store = new Map<string, Node>();
-  watcher?: FSWatcher;
+  readonly store: Map<string, Node>;
+  private _watcher?: FSWatcher;
 
-  public put(value: Node | Node[]) {
+  constructor(store?: Map<string, Node>) {
+    this.store = store ?? new Map<string, Node>();
+  }
+
+  get watcher(): FSWatcher | undefined {
+    return this._watcher;
+  }
+
+  set watcher(watcher: FSWatcher | undefined) {
+    this._watcher = watcher;
+  }
+
+  put(value: Node | Node[]) {
     if (value instanceof Array) {
       for (const node of value) {
         this.insert(node);
@@ -57,23 +69,23 @@ export class BuildGraph implements Traversable<Node> {
     this.store.set(node.url, node);
   }
 
-  public get(url: string): Node {
+  get(url: string): Node {
     return this.store.get(url);
   }
 
-  public has(url: string): boolean {
+  has(url: string): boolean {
     return this.store.has(url);
   }
 
-  public entries(): Node[] {
+  entries(): Node[] {
     return Array.from(this.store.values());
   }
 
-  public values(): IterableIterator<Node> {
+  values(): IterableIterator<Node> {
     return this.store.values();
   }
 
-  public some<T extends Node = Node>(by: ComplexPredicate<Node, T>): boolean {
+  some<T extends Node = Node>(by: ComplexPredicate<Node, T>): boolean {
     for (const node of this.store.values()) {
       if (by(node)) {
         return true;
@@ -83,7 +95,7 @@ export class BuildGraph implements Traversable<Node> {
     return false;
   }
 
-  public filter<T extends Node = Node>(by: ComplexPredicate<Node, T>): T[] {
+  filter<T extends Node = Node>(by: ComplexPredicate<Node, T>): T[] {
     const result: T[] = [];
 
     for (const node of this.store.values()) {
@@ -95,7 +107,7 @@ export class BuildGraph implements Traversable<Node> {
     return result;
   }
 
-  public find<T extends Node = Node>(by: ComplexPredicate<Node, T>): T | undefined {
+  find<T extends Node = Node>(by: ComplexPredicate<Node, T>): T | undefined {
     for (const node of this.store.values()) {
       if (by(node)) {
         return node as T;
@@ -108,4 +120,25 @@ export class BuildGraph implements Traversable<Node> {
   get size(): number {
     return this.store.size;
   }
+}
+
+export class ScopedBuildGraph<T extends Node = Node> extends BuildGraph {
+  constructor(
+    readonly parentGraph: BuildGraph,
+    readonly activeEntryPoint: T,
+  ) {
+    super(parentGraph.store);
+  }
+
+  override get watcher(): FSWatcher | undefined {
+    return this.parentGraph.watcher;
+  }
+
+  override set watcher(watcher: FSWatcher | undefined) {
+    this.parentGraph.watcher = watcher;
+  }
+}
+
+export function isScopedBuildGraph<T extends Node = Node>(graph: BuildGraph): graph is ScopedBuildGraph<T> {
+  return graph instanceof ScopedBuildGraph;
 }

--- a/src/lib/ng-package/entry-point/compile-ngc.transform.ts
+++ b/src/lib/ng-package/entry-point/compile-ngc.transform.ts
@@ -1,12 +1,11 @@
 import ora from 'ora';
 import * as path from 'path';
 import ts from 'typescript';
-import { isInProgress } from '../../graph/select';
 import { Transform, transformFromPromise } from '../../graph/transform';
 import { compileSourceFiles } from '../../ngc/compile-source-files';
 import { StylesheetProcessor as StylesheetProcessorClass } from '../../styles/stylesheet-processor';
 import { setDependenciesTsConfigPaths } from '../../ts/tsconfig';
-import { EntryPointNode, PackageNode, isEntryPoint, isPackage } from '../nodes';
+import { findPackageNode, getActiveEntryPoint, isEntryPoint } from '../nodes';
 import { NgPackagrOptions } from '../options.di';
 
 export const compileNgcTransformFactory = (
@@ -19,22 +18,9 @@ export const compileNgcTransformFactory = (
       discardStdin: false,
     });
 
-    const entryPoints: EntryPointNode[] = [];
-    let entryPoint: EntryPointNode;
-    let ngPackageNode: PackageNode;
-
-    for (const node of graph.values()) {
-      if (isEntryPoint(node)) {
-        entryPoints.push(node);
-
-        if (isInProgress(node)) {
-          entryPoint = node;
-        }
-      } else if (isPackage(node)) {
-        ngPackageNode = node;
-      }
-    }
-
+    const entryPoints = graph.filter(isEntryPoint);
+    const ngPackageNode = findPackageNode(graph);
+    const entryPoint = getActiveEntryPoint(graph);
     const projectBasePath = ngPackageNode.data.primary.basePath;
 
     try {
@@ -42,7 +28,7 @@ export const compileNgcTransformFactory = (
       const tsConfig = setDependenciesTsConfigPaths(entryPoint.data.tsConfig, entryPoints);
 
       // Compile TypeScript sources
-      const { esm2022: esm2022, declarations } = entryPoint.data.destinationFiles;
+      const { esm2022, declarations } = entryPoint.data.destinationFiles;
       const { basePath, cssUrl, styleIncludePaths, sass } = entryPoint.data.entryPoint;
       const { moduleResolutionCache } = entryPoint.cache;
 
@@ -76,10 +62,6 @@ export const compileNgcTransformFactory = (
     } catch (error) {
       spinner.fail();
       throw error;
-    } finally {
-      if (!options.watch) {
-        entryPoint.cache.stylesheetProcessor?.destroy();
-      }
     }
 
     spinner.succeed();

--- a/src/lib/ng-package/entry-point/entry-point.transform.ts
+++ b/src/lib/ng-package/entry-point/entry-point.transform.ts
@@ -2,7 +2,7 @@ import { pipe, tap } from 'rxjs';
 import { STATE_DONE } from '../../graph/node';
 import { Transform } from '../../graph/transform';
 import * as log from '../../utils/log';
-import { findEntryPointInProgress } from '../nodes';
+import { getActiveEntryPoint } from '../nodes';
 
 /**
  * A re-write of the `transformSources()` script that transforms an entry point from sources to distributable format.
@@ -37,7 +37,7 @@ export const entryPointTransformFactory = (
   pipe(
     tap(graph => {
       // Peek the first entry point from the graph
-      const entryPoint = findEntryPointInProgress(graph);
+      const entryPoint = getActiveEntryPoint(graph);
       log.msg('\n------------------------------------------------------------------------------');
       log.msg(`Building entry point '${entryPoint.data.entryPoint.moduleId}'`);
       log.msg('------------------------------------------------------------------------------');
@@ -48,7 +48,7 @@ export const entryPointTransformFactory = (
     writeBundles,
     writePackage,
     tap(graph => {
-      const entryPoint = findEntryPointInProgress(graph);
+      const entryPoint = getActiveEntryPoint(graph);
       entryPoint.state = STATE_DONE;
     }),
   );

--- a/src/lib/ng-package/entry-point/write-bundles.transform.ts
+++ b/src/lib/ng-package/entry-point/write-bundles.transform.ts
@@ -7,7 +7,7 @@ import { transformFromPromise } from '../../graph/transform';
 import { generateKey, readCacheEntry, saveCacheEntry } from '../../utils/cache';
 import { exists, mkdir, writeFile } from '../../utils/fs';
 import { ensureUnixPath } from '../../utils/path';
-import { findEntryPointInProgress } from '../nodes';
+import { getActiveEntryPoint } from '../nodes';
 import { NgPackagrOptions } from '../options.di';
 
 type CachedBundleFile =
@@ -30,7 +30,7 @@ interface BundlesCache {
 
 export const writeBundlesTransform = (options: NgPackagrOptions) =>
   transformFromPromise(async graph => {
-    const entryPoint = findEntryPointInProgress(graph);
+    const entryPoint = getActiveEntryPoint(graph);
     const { destinationFiles, entryPoint: ngEntryPoint, tsConfig } = entryPoint.data;
     const cache = entryPoint.cache;
     const { fesm2022Dir, esm2022, declarations, declarationsDir } = destinationFiles;
@@ -46,8 +46,12 @@ export const writeBundlesTransform = (options: NgPackagrOptions) =>
       tsConfig.options.compilationMode,
       (tsConfig.options.declarationMap ?? false).toString(),
     );
-
-    const hash = await generateKey([...cache.outputCache.values()].map(({ version }) => version).join(':'));
+    const hash = await generateKey(
+      [...cache.outputCache.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([p, { version }]) => `${p}:${version}`)
+        .join(':'),
+    );
     const cacheDirectory = options.cacheEnabled && options.cacheDirectory;
     if (cacheDirectory) {
       const cacheResult: BundlesCache = await readCacheEntry(options.cacheDirectory, cacheKey);

--- a/src/lib/ng-package/entry-point/write-package.transform.ts
+++ b/src/lib/ng-package/entry-point/write-package.transform.ts
@@ -4,14 +4,13 @@ import { glob } from 'tinyglobby';
 import { AssetPattern } from '../../../ng-package.schema';
 import { BuildGraph } from '../../graph/build-graph';
 import { Node } from '../../graph/node';
-import { isInProgress } from '../../graph/select';
 import { transformFromPromise } from '../../graph/transform';
 import { colors } from '../../utils/color';
 import { copyFile, mkdir, rmdir, stat, writeFile } from '../../utils/fs';
 import * as log from '../../utils/log';
 import { ConditionalExport, generatePackageExports, generateWatchVersion } from '../../utils/package-json';
 import { ensureUnixPath } from '../../utils/path';
-import { EntryPointNode, PackageNode, fileUrl, findPackageNode, isEntryPoint } from '../nodes';
+import { EntryPointNode, PackageNode, fileUrl, findPackageNode, getActiveEntryPoint, isEntryPoint } from '../nodes';
 import { NgPackagrOptions } from '../options.di';
 import { NgPackage } from '../package';
 import { NgEntryPoint } from './entry-point';
@@ -22,7 +21,7 @@ export const writePackageTransform = (options: NgPackagrOptions) =>
   transformFromPromise(async graph => {
     const spinner = ora({ hideCursor: false, discardStdin: false });
     const entryPoints = graph.filter(isEntryPoint);
-    const entryPoint = entryPoints.find(isInProgress);
+    const entryPoint = getActiveEntryPoint(graph);
     const ngEntryPoint: NgEntryPoint = entryPoint.data.entryPoint;
     const ngPackageNode = findPackageNode(graph);
     const ngPackage = ngPackageNode.data;

--- a/src/lib/ng-package/nodes.ts
+++ b/src/lib/ng-package/nodes.ts
@@ -1,7 +1,7 @@
 import type { NgtscProgram, ParsedConfiguration } from '@angular/compiler-cli';
 import ts from 'typescript';
 import { FileCache } from '../file-system/file-cache';
-import { BuildGraph, ComplexPredicate } from '../graph/build-graph';
+import { BuildGraph, ComplexPredicate, isScopedBuildGraph } from '../graph/build-graph';
 import { Node } from '../graph/node';
 import { by, isInProgress, isPending } from '../graph/select';
 import { AngularDiagnosticsCache } from '../ngc/angular-diagnostics-cache';
@@ -38,13 +38,29 @@ export function isEntryPointPending(): ComplexPredicate<EntryPointNode> {
   return by(n => isEntryPoint(n) && isPending(n));
 }
 
-export function findEntryPointInProgress(graph: BuildGraph): EntryPointNode {
-  const entryPoint = graph.find(isEntryPointInProgress());
-  if (!entryPoint) {
-    throw new Error('Could not find entry point in progress');
+export function getActiveEntryPoint(graph: BuildGraph): EntryPointNode {
+  if (isScopedBuildGraph(graph) && isEntryPoint(graph.activeEntryPoint)) {
+    return graph.activeEntryPoint;
   }
 
-  return entryPoint;
+  return findEntryPointInProgress(graph);
+}
+
+export function findEntryPointInProgress(graph: BuildGraph): EntryPointNode {
+  if (isScopedBuildGraph(graph) && isEntryPoint(graph.activeEntryPoint)) {
+    return graph.activeEntryPoint;
+  }
+
+  const inProgress = graph.filter(isEntryPointInProgress());
+  if (inProgress.length === 1) {
+    return inProgress[0];
+  }
+  if (inProgress.length > 1) {
+    const moduleIds = inProgress.map(e => e.data.entryPoint.moduleId).join(', ');
+    throw new Error(`Multiple entry points are in progress (${moduleIds}). A ScopedBuildGraph is required.`);
+  }
+
+  throw new Error('Could not find entry point in progress');
 }
 
 export function findPackageNode(graph: BuildGraph): PackageNode {

--- a/src/lib/ng-package/package.transform.ts
+++ b/src/lib/ng-package/package.transform.ts
@@ -1,15 +1,15 @@
 import { DepGraph } from 'dependency-graph';
+import { availableParallelism } from 'node:os';
 import {
   EMPTY,
   NEVER,
   Observable,
+  Subscription,
   catchError,
   concatMap,
   debounceTime,
-  defaultIfEmpty,
   filter,
   finalize,
-  from,
   last,
   map,
   of as observableOf,
@@ -18,11 +18,10 @@ import {
   repeat,
   startWith,
   switchMap,
-  takeLast,
   tap,
 } from 'rxjs';
 import { createFileWatch, invalidateEntryPointsAndCacheOnFileChange } from '../file-system/file-watcher';
-import { BuildGraph } from '../graph/build-graph';
+import { BuildGraph, ScopedBuildGraph } from '../graph/build-graph';
 import { Node, STATE_DONE, STATE_ERROR, STATE_IN_PROGRESS, STATE_PENDING } from '../graph/node';
 import { Transform } from '../graph/transform';
 import { shutdownSassWorkerPool } from '../styles/stylesheets/sass-language';
@@ -30,15 +29,7 @@ import { colors } from '../utils/color';
 import { rmdir } from '../utils/fs';
 import * as log from '../utils/log';
 import { discoverPackages } from './discover-packages';
-import {
-  EntryPointNode,
-  PackageNode,
-  byEntryPoint,
-  findPackageNode,
-  isEntryPoint,
-  isEntryPointPending,
-  ngUrl,
-} from './nodes';
+import { EntryPointNode, PackageNode, findPackageNode, isEntryPoint, isEntryPointPending, ngUrl } from './nodes';
 import { NgPackagrOptions } from './options.di';
 
 /**
@@ -193,58 +184,202 @@ const buildTransformFactory =
 
 const scheduleEntryPoints = (epTransform: Transform, options: NgPackagrOptions): Transform =>
   pipe(
-    concatMap(graph => {
-      // Calculate node/dependency depth and determine build order
-      const depGraph = new DepGraph({ circular: false });
-      for (const node of graph.values()) {
-        if (!isEntryPoint(node)) {
-          continue;
-        }
+    concatMap(
+      graph =>
+        new Observable<BuildGraph>(subscriber => {
+          // Calculate node/dependency depth and determine build order
+          const depGraph = new DepGraph({ circular: false });
+          const entryPoints = new Map<string, EntryPointNode>();
 
-        // Remove `ng://` prefix for better error messages
-        const from = node.url.substring(5);
-        depGraph.addNode(from);
+          for (const node of graph.values()) {
+            if (!isEntryPoint(node)) {
+              continue;
+            }
 
-        for (const dep of node.dependents) {
-          if (!isEntryPoint(dep)) {
-            continue;
+            // Remove `ng://` prefix for better error messages
+            const from = node.url.startsWith('ng://') ? node.url.slice(5) : node.url;
+            entryPoints.set(from, node);
+            depGraph.addNode(from);
+
+            for (const dep of node.dependents) {
+              if (!isEntryPoint(dep)) {
+                continue;
+              }
+
+              const to = dep.url.startsWith('ng://') ? dep.url.slice(5) : dep.url;
+              depGraph.addNode(to);
+              depGraph.addDependency(from, to);
+            }
           }
 
-          const to = dep.url.substring(5);
-          depGraph.addNode(to);
-          depGraph.addDependency(from, to);
-        }
-      }
+          // Topological sort will throw a DependencyCycleError if cycles exist
+          const overallOrder = depGraph.overallOrder();
+          const pending = new Set<string>();
 
-      // The array index is the depth.
-      const groups = depGraph.overallOrder().map(ngUrl);
+          for (const id of overallOrder) {
+            const ep = entryPoints.get(id);
+            if (ep && ep.state !== STATE_DONE) {
+              pending.add(id);
+            }
+          }
 
-      // Build entry points with lower depth values first.
-      return from(groups).pipe(
-        map((epUrl: string): EntryPointNode => graph.find(byEntryPoint().and(ep => ep.url === epUrl))),
-        filter((entryPoint: EntryPointNode): boolean => entryPoint.state !== STATE_DONE),
-        concatMap(ep =>
-          observableOf(ep).pipe(
-            // Mark the entry point as 'in-progress'
-            tap(entryPoint => (entryPoint.state = STATE_IN_PROGRESS)),
-            map(() => graph),
-            epTransform,
-            catchError(err => {
-              ep.state = STATE_ERROR;
+          if (pending.size === 0) {
+            subscriber.next(graph);
+            subscriber.complete();
 
-              throw err;
-            }),
-            finalize(() => {
-              if (!options.watch) {
-                ep.dispose();
+            return;
+          }
+
+          const inDegree = new Map<string, number>();
+          const readyQueue: string[] = [];
+
+          for (const id of pending) {
+            const directDeps = depGraph.directDependenciesOf(id);
+            let pendingDepsCount = 0;
+            for (const dep of directDeps) {
+              if (pending.has(dep)) {
+                pendingDepsCount++;
               }
-            }),
-          ),
-        ),
-        takeLast(1), // don't use last as sometimes it this will cause 'no elements in sequence',
-        defaultIfEmpty(graph),
-      );
-    }),
+            }
+            inDegree.set(id, pendingDepsCount);
+            if (pendingDepsCount === 0) {
+              readyQueue.push(id);
+            }
+          }
+
+          const maxConcurrency = Math.max(1, Math.min(availableParallelism() - 1, 8));
+          let activeCount = 0;
+          let buildError: unknown = null;
+          let isCancelled = false;
+          const activeSubscriptions = new Set<Subscription>();
+
+          const toError = (err: unknown): Error => {
+            if (err instanceof Error) {
+              return err;
+            }
+            if (typeof err === 'string') {
+              return new Error(err);
+            }
+            if (
+              err &&
+              typeof err === 'object' &&
+              'message' in err &&
+              typeof (err as { message: unknown }).message === 'string'
+            ) {
+              return new Error((err as { message: string }).message);
+            }
+
+            return new Error('Build error');
+          };
+
+          const next = () => {
+            if (isCancelled) {
+              return;
+            }
+
+            if (buildError) {
+              if (activeCount === 0) {
+                subscriber.error(toError(buildError));
+              }
+
+              return;
+            }
+
+            if (pending.size === 0 && activeCount === 0) {
+              subscriber.next(graph);
+              subscriber.complete();
+
+              return;
+            }
+
+            if (activeCount === 0 && readyQueue.length === 0 && pending.size > 0) {
+              const pendingIds = [...pending].join(', ');
+              subscriber.error(new Error(`Deadlock detected: unresolved dependencies for [${pendingIds}]`));
+
+              return;
+            }
+
+            while (activeCount < maxConcurrency && readyQueue.length > 0) {
+              const id = readyQueue.shift();
+              if (!id) {
+                break;
+              }
+
+              const ep = entryPoints.get(id);
+              if (!ep) {
+                buildError = new Error(`Entry point node not found for '${id}'`);
+                readyQueue.length = 0;
+                if (activeCount === 0) {
+                  subscriber.error(toError(buildError));
+                }
+
+                return;
+              }
+
+              activeCount++;
+
+              const scopedGraph = new ScopedBuildGraph(graph, ep);
+              const run$ = of(scopedGraph).pipe(
+                tap(() => {
+                  ep.state = STATE_IN_PROGRESS;
+                }),
+                epTransform,
+                catchError(err => {
+                  ep.state = STATE_ERROR;
+                  throw err;
+                }),
+                finalize(() => {
+                  if (!options.watch) {
+                    ep.dispose();
+                  }
+                }),
+              );
+
+              const sub: Subscription = run$.subscribe({
+                error: err => {
+                  activeSubscriptions.delete(sub);
+                  activeCount--;
+                  if (!buildError) {
+                    buildError = err;
+                    readyQueue.length = 0;
+                  }
+                  next();
+                },
+                complete: () => {
+                  activeSubscriptions.delete(sub);
+                  activeCount--;
+                  pending.delete(id);
+
+                  for (const depId of depGraph.directDependantsOf(id)) {
+                    if (pending.has(depId)) {
+                      const remaining = (inDegree.get(depId) ?? 1) - 1;
+                      inDegree.set(depId, remaining);
+                      if (remaining === 0) {
+                        readyQueue.push(depId);
+                      }
+                    }
+                  }
+
+                  next();
+                },
+              });
+
+              activeSubscriptions.add(sub);
+            }
+          };
+
+          next();
+
+          return () => {
+            isCancelled = true;
+            readyQueue.length = 0;
+            for (const activeSub of activeSubscriptions) {
+              activeSub.unsubscribe();
+            }
+            activeSubscriptions.clear();
+          };
+        }),
+    ),
   );
 
 function printBuiltAngularPackage(ngPackage: Node, startTime: number): void {

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -2,7 +2,7 @@ import { CompilerOptions, NgtscProgram, ParsedConfiguration, formatDiagnostics }
 import { join } from 'node:path';
 import ts from 'typescript';
 import { BuildGraph } from '../graph/build-graph';
-import { findEntryPointInProgress, findPackageNode } from '../ng-package/nodes';
+import { findPackageNode, getActiveEntryPoint } from '../ng-package/nodes';
 import { NgPackagrOptions } from '../ng-package/options.di';
 import { StylesheetProcessor } from '../styles/stylesheet-processor';
 import { augmentProgramWithVersioning, cacheCompilerHost } from '../ts/cache-compiler-host';
@@ -26,7 +26,7 @@ export async function compileSourceFiles(
 ) {
   const { cacheDirectory, watch, cacheEnabled } = options;
   const tsConfigOptions: CompilerOptions = { ...tsConfig.options, ...extraOptions };
-  const entryPoint = findEntryPointInProgress(graph);
+  const entryPoint = getActiveEntryPoint(graph);
   const ngPackageNode = findPackageNode(graph);
   const inlineStyleLanguage = ngPackageNode.data.inlineStyleLanguage;
 

--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import ts from 'typescript';
 import { NgPackageConfig } from '../../ng-package.schema';
 import { FileCache } from '../file-system/file-cache';
-import { BuildGraph } from '../graph/build-graph';
+import { BuildGraph, isScopedBuildGraph } from '../graph/build-graph';
 import { Node } from '../graph/node';
 import { EntryPointNode, fileUrl } from '../ng-package/nodes';
 import { StylesheetProcessor } from '../styles/stylesheet-processor';
@@ -23,14 +23,15 @@ export function cacheCompilerHost(
   sourcesFileCache: FileCache = entryPoint.cache.sourcesFileCache,
 ): CompilerHost {
   const compilerHost = ts.createIncrementalCompilerHost(compilerOptions);
+  const rootGraph = isScopedBuildGraph(graph) ? graph.parentGraph : graph;
 
   const getNode = (fileName: string) => {
     const nodeUri = fileUrl(ensureUnixPath(fileName));
-    let node = graph.get(nodeUri);
+    let node = rootGraph.get(nodeUri);
 
     if (!node) {
       node = new Node(nodeUri);
-      graph.put(node);
+      rootGraph.put(node);
     }
 
     return node;


### PR DESCRIPTION
### Summary
This change parallelizes the compilation and packaging of independent entry points based on their topological dependency graph instead of processing them strictly sequentially.

### Key Changes
1. **Parallel DAG Scheduling (Kahn's Algorithm)**:
   - Tracks dependency in-degrees across pending entry points.
   - Concurrently executes entry points whose dependencies are fulfilled, bounded by available system parallelism (`Math.max(1, Math.min(availableParallelism() - 1, 8))`).
   - Dynamically unlocks dependants as in-flight tasks finish.
   - Built with an RxJS Observable offering graceful unsubscription cancellation, error draining before propagation, and deadlock detection.

2. **`ScopedBuildGraph` Isolation**:
   - Introduces `ScopedBuildGraph` extending `BuildGraph` to isolate the active entry point per concurrent task while sharing the underlying node store.
   - Exposes `getActiveEntryPoint(graph)` to safely identify the currently compiling entry point without ambient `isInProgress` ambiguity.

3. **Lifecycle & Resource Cleanup**:
   - Centralizes resource disposal in `EntryPointNode.dispose()`, invoked during entry point pipeline finalization.
   - Unwraps `rootGraph` in `cacheCompilerHost` to prevent retaining `ScopedBuildGraph` references across builds.

4. **Deterministic Caching**:
   - Sorts `outputCache` entries by path when computing bundle cache keys to ensure deterministic hashing across concurrent tasks.